### PR TITLE
Jorge Trait

### DIFF
--- a/bin/jorge
+++ b/bin/jorge
@@ -18,4 +18,4 @@ use MountHolyoke\Jorge\Jorge;
 
 $JORGE = new Jorge();
 $JORGE->configure();
-$JORGE->run($JORGE->input, $JORGE->output);
+$JORGE->run();

--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -10,9 +10,18 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Provides a Jorge command that can execute Drush commands.
+ *
+ * @link https://github.com/mtholyoke/jorge
+ *
+ * @author Jason Proctor <jproctor@mtholyoke.edu>
+ * @copyright 2018 Trustees of Mount Holyoke College
+ */
 class DrushCommand extends Command {
   use JorgeTrait;
 
+  /** @var string $drush_command The actual drush command with its arguments and options */
   protected $drush_command = '';
 
   /**
@@ -41,6 +50,13 @@ only apply to Drush, you can escape -v/--verbose as above.
 
   /**
    * Initializes the `drush` command.
+   *
+   * Parses the command-line arguments and options to assemble the actual
+   * command string to send to Drush.
+   * @uses \MountHolyoke\Jorge\Helper\JorgeTrait::initializeJorge()
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface   $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
     $this->initializeJorge();
@@ -59,6 +75,12 @@ only apply to Drush, you can escape -v/--verbose as above.
 
   /**
    * Executes the `drush` command.
+   *
+   * Assembles the drush command and passes it to the 'lando' tool.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface   $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return null|int
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     $lando  = $this->jorge->getTool('lando');
@@ -73,6 +95,6 @@ only apply to Drush, you can escape -v/--verbose as above.
     if (!$lando->getStatus()->running) {
       $lando->run('start');
     }
-    $lando->run($drush);
+    return $lando->run($drush);
   }
 }

--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -77,6 +77,7 @@ only apply to Drush, you can escape -v/--verbose as above.
    * Executes the `drush` command.
    *
    * Assembles the drush command and passes it to the 'lando' tool.
+   * @todo If I have a sequence of calls, could I share the Lando bootstrap?
    *
    * @param \Symfony\Component\Console\Input\InputInterface   $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output

--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -2,6 +2,7 @@
 
 namespace MountHolyoke\Jorge\Command;
 
+use MountHolyoke\Jorge\Helper\JorgeTrait;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -10,8 +11,9 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class DrushCommand extends Command {
+  use JorgeTrait;
+
   protected $drush_command = '';
-  protected $jorge;
 
   /**
    * Establishes the `drush` command.
@@ -41,8 +43,8 @@ only apply to Drush, you can escape -v/--verbose as above.
    * Initializes the `drush` command.
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
-    $this->verbosity = $output->getVerbosity();
-    $this->jorge = $this->getApplication();
+    $this->initializeJorge($input, $output);
+
     $arguments = $input->getArgument('drush_command');
     if (!empty($arguments)) {
       if ($input->hasOption('yes') && $input->getOption('yes')) {
@@ -53,12 +55,6 @@ only apply to Drush, you can escape -v/--verbose as above.
     if ($this->verbosity > OutputInterface::VERBOSITY_NORMAL) {
       $this->drush_command = trim($this->drush_command . ' --verbose');
     }
-
-    $this->jorge->log(
-      LogLevel::DEBUG,
-      'Drush command: "{%command}"',
-      ['%command' => $this->drush_command]
-    );
   }
 
   /**
@@ -70,7 +66,7 @@ only apply to Drush, you can escape -v/--verbose as above.
     $webdir = $this->jorge->getPath('web', TRUE);
 
     if (!$lando->isEnabled()) {
-      $this->jorge->log(LogLevel::ERROR, 'Cannot run Drush without Lando');
+      $this->log(LogLevel::ERROR, 'Cannot run without Lando');
       return;
     }
     chdir($webdir);

--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -43,7 +43,7 @@ only apply to Drush, you can escape -v/--verbose as above.
    * Initializes the `drush` command.
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
-    $this->initializeJorge($input, $output);
+    $this->initializeJorge();
 
     $arguments = $input->getArgument('drush_command');
     if (!empty($arguments)) {

--- a/src/Command/HonkCommand.php
+++ b/src/Command/HonkCommand.php
@@ -6,6 +6,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * Provides a Jorge command that can “honk”.
+ *
+ * @link https://github.com/mtholyoke/jorge
+ *
+ * @author Jason Proctor <jproctor@mtholyoke.edu>
+ * @copyright 2018 Trustees of Mount Holyoke College
+ */
 class HonkCommand extends Command {
   /**
    * Establishes the `honk` command.
@@ -20,6 +28,12 @@ class HonkCommand extends Command {
 
   /**
    * Executes the `honk` command.
+   *
+   * Output includes ^G for a beep.
+   *
+   * @param \Symfony\Component\Console\Input\InputInterface   $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   * @return null|int
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     $output->writeln('Honk!');

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -154,7 +154,7 @@ class ResetCommand extends Command {
 
     foreach ($drushSequence as $step) {
       $drushInput = new ArrayInput($step);
-      $drush->run($drushInput, $this->jorge->output);
+      $drush->run($drushInput, $this->jorge->getOutput());
     }
   }
 

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -139,7 +139,6 @@ class ResetCommand extends Command {
    * Defines and runs the sequence necessary to reset a Drupal 8 site.
    *
    * Assumes Git, Composer, and Lando for a Pantheon-hosted site.
-   * @todo Finish implementing Lando tool
    * @todo Implement tools for Git and Composer
    * @todo Construct a real return value
    * @todo Refactor into a DDL?
@@ -154,19 +153,19 @@ class ResetCommand extends Command {
     if (!$lando->getStatus()->running) {
       $lando->run('start');
     }
-    $lando_pull = 'lando pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
-    if ($this->params['rsync']) {
-      $lando_pull .= ' --rsync';
-    }
     $steps = [
       'git checkout ' . $this->params['branch'],
       'git pull',
       'composer install',
-      $lando_pull,
     ];
     foreach ($steps as $step) {
       $this->processStep($step);
     }
+    $lando_pull = 'pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
+    if ($this->params['rsync']) {
+      $lando_pull .= ' --rsync';
+    }
+    $lando->run($lando_pull);
 
     $drush = $this->jorge->find('drush');
     $drushSequence = [

--- a/src/Helper/JorgeTrait.php
+++ b/src/Helper/JorgeTrait.php
@@ -7,16 +7,25 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Parent class for Jorge commands to collect some common functionality.
+ *
+ * @link https://github.com/mtholyoke/jorge
+ *
+ * @author Jason Proctor <jproctor@mtholyoke.edu>
+ * @copyright 2018 Trustees of Mount Holyoke College
  */
-trait JorgeTrait{
+trait JorgeTrait {
+  /** @var \MountHolyoke\Jorge\Jorge $jorge The running application */
   protected $jorge = NULL;
+
+  /** @var int $verbosity The verbosity level specified on the command line */
   protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
 
   /**
    * Establish some properties that are common to all Jorge commands and tools.
    *
-   * This should be called from the initialize() method in each. Note that for
-   * tools it’s called during setup phase, but commands don’t call it until run().
+   * This should be called from the initialize() method in each command (which
+   * is not invoked until the command is being run). Tools get it automatically:
+   * @used-by \MountHolyoke\Jorge\Tool\Tool::setApplication()
    */
   protected function initializeJorge() {
     $this->jorge = $this->getApplication();
@@ -26,7 +35,7 @@ trait JorgeTrait{
   /**
    * Sends a message prefixed with command name to the application’s logger.
    *
-   * @param string|NULL $level   What log level to use, or NULL to ignore
+   * @param string|null $level   What log level to use, or NULL to ignore
    * @param string      $message May need $context interpolation
    * @param array       $context Variable substitutions for $message
    * @see Symfony\Component\Console\Logger\ConsoleLogger

--- a/src/Helper/JorgeTrait.php
+++ b/src/Helper/JorgeTrait.php
@@ -20,22 +20,32 @@ trait JorgeTrait{
    */
   protected function initializeJorge() {
     $this->jorge = $this->getApplication();
-    $this->verbosity = $this->jorge->output->getVerbosity();
+    $this->verbosity = $this->jorge->getOutput()->getVerbosity();
   }
 
   /**
    * Sends a message prefixed with command name to the application’s logger.
    *
-   * @param string|NULL what log level to use, or NULL to ignore.
-   * @param string the message
-   * @param array variable substitutions for the message
+   * @param string|NULL $level   What log level to use, or NULL to ignore
+   * @param string      $message May need $context interpolation
+   * @param array       $context Variable substitutions for $message
+   * @see Symfony\Component\Console\Logger\ConsoleLogger
    */
-   protected function log($level, $message, array $context = []) {
-     if ($level !== NULL) {
-       $message = '{' . $this->getName() . '} ' . $message;
-       $this->jorge->log($level, $message, $context);
-     }
-   }
+  protected function log($level, $message, array $context = []) {
+    if ($level !== NULL) {
+      $message = '{' . $this->getName() . '} ' . $message;
+      $this->jorge->log($level, $message, $context);
+    }
+  }
 
-
+  /**
+   * Sends text directly to the application's output interface.
+   *
+   * @param string|array $messages The message as an array of lines of a single string
+   * @param int          $options  A bitmask of options
+   * @see Symfony\Component\Console\Output\OutputInterface
+   */
+  protected function writeln($messages, $options = 0) {
+    $this->jorge->getOutput()->writeln($messages, $options);
+  }
 }

--- a/src/Helper/JorgeTrait.php
+++ b/src/Helper/JorgeTrait.php
@@ -3,7 +3,6 @@
 namespace MountHolyoke\Jorge\Helper;
 
 use Psr\Log\LogLevel;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -18,13 +17,10 @@ trait JorgeTrait{
    *
    * This should be called from the initialize() method in each. Note that for
    * tools it’s called during setup phase, but commands don’t call it until run().
-   *
-   * @param InputInterface
-   * @param OutputInterface
    */
-  protected function initializeJorge(InputInterface $input, OutputInterface $output) {
+  protected function initializeJorge() {
     $this->jorge = $this->getApplication();
-    $this->verbosity = $output->getVerbosity();
+    $this->verbosity = $this->jorge->output->getVerbosity();
   }
 
   /**

--- a/src/Helper/JorgeTrait.php
+++ b/src/Helper/JorgeTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace MountHolyoke\Jorge\Helper;
+
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Parent class for Jorge commands to collect some common functionality.
+ */
+trait JorgeTrait{
+  protected $jorge = NULL;
+  protected $verbosity = OutputInterface::VERBOSITY_NORMAL;
+
+  /**
+   * Establish some properties that are common to all Jorge commands and tools.
+   *
+   * This should be called from the initialize() method in each. Note that for
+   * tools it’s called during setup phase, but commands don’t call it until run().
+   *
+   * @param InputInterface
+   * @param OutputInterface
+   */
+  protected function initializeJorge(InputInterface $input, OutputInterface $output) {
+    $this->jorge = $this->getApplication();
+    $this->verbosity = $output->getVerbosity();
+  }
+
+  /**
+   * Sends a message prefixed with command name to the application’s logger.
+   *
+   * @param string|NULL what log level to use, or NULL to ignore.
+   * @param string the message
+   * @param array variable substitutions for the message
+   */
+   protected function log($level, $message, array $context = []) {
+     if ($level !== NULL) {
+       $message = '{' . $this->getName() . '} ' . $message;
+       $this->jorge->log($level, $message, $context);
+     }
+   }
+
+
+}

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -17,12 +17,11 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Yaml\Yaml;
 
 class Jorge extends Application {
-  public $config = [];
+  private $config = [];
   public $input;
-  public $logger;
-  private $messages = [];
+  private $logger;
   public $output;
-  public $rootPath;
+  private $rootPath;
   private $tools;
 
   /**
@@ -104,6 +103,19 @@ class Jorge extends Application {
     }
     $this->logger->warning('Can’t find project root');
     return FALSE;
+  }
+
+  /**
+   * Return a parameter from configuration.
+   *
+   * @param string $key The key to get from config
+   * @param mixed $default The value to return if key not present
+   */
+  public function getConfig($key, $default = NULL) {
+    if (array_key_exists($key, $this->config)) {
+      return $this->config[$key];
+    }
+    return $default;
   }
 
   /**

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -18,12 +18,35 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * Extends \Symfony\Component\Console\Application with new functionality.
+ *
+ * Jorge is used as a fancy shell script—it consolidates common sequences
+ * of commands necessary to maintain a local development environment for
+ * other applications.
+ *
+ * @link https://github.com/mtholyoke/jorge
+ *
+ * @author Jason Proctor <jproctor@mtholyoke.edu>
+ * @copyright 2018 Trustees of Mount Holyoke College
+ */
 class Jorge extends Application {
+  /** @var array $config Project configuration from .jorge/config.yml */
   private $config = [];
+
+  /** @var \Symfony\Component\Console\Input\InputInterface $input */
   private $input;
+
+  /** @var \Symfony\Component\Console\Logger\ConsoleLogger $logger */
   private $logger;
+
+  /** @var \Symfony\Component\Console\Output\OutputInterface $output */
   private $output;
+
+  /** @var string $rootPath The fully qualified path of the project root */
   private $rootPath;
+
+  /** @var array $tools The instances of Tool\Tool available to this app. */
   private $tools;
 
   /**
@@ -70,15 +93,15 @@ class Jorge extends Application {
   }
 
   /**
-   * Adds a command-line tool to be used by commands.
+   * Adds a Tool\Tool representation of a command-line tool.
    *
-   * Adapted from Symfony\Component\Console\Application::add().
+   * Adapted from \Symfony\Component\Console\Application::add().
    *
-   * @param Tool an instance of the tool to add
-   * @param string executable command if different from name
-   * @return Tool the tool as added
+   * @param Tool\Tool $tool       An instance of the tool to add
+   * @param string    $executable Command if different from name
+   * @return Tool\Tool
    */
-  private function addTool(Tool $tool, $executable = '') {
+  public function addTool(Tool $tool, $executable = '') {
     $name = $tool->setApplication($this, $executable)->getName();
     if (empty($name)) {
       throw new LogicException(sprintf('The tool defined in "%s" has an invalid or empty name.', get_class($tool)));
@@ -91,7 +114,7 @@ class Jorge extends Application {
    * Traverses up the directory tree from current location until it finds the
    * project root, defined as a directory that contains a .jorge directory.
    *
-   * @return string|FALSE full path to document root, or FALSE if none found
+   * @return string|false full path to document root, or FALSE if none found
    */
   private function findRootPath() {
     $wd = explode('/', getcwd());
@@ -110,8 +133,8 @@ class Jorge extends Application {
   /**
    * Return a parameter from configuration.
    *
-   * @param string $key The key to get from config
-   * @param mixed $default The value to return if key not present
+   * @param string $key     The key to get from config
+   * @param mixed  $default The value to return if key not present
    */
   public function getConfig($key, $default = NULL) {
     if (array_key_exists($key, $this->config)) {
@@ -121,21 +144,21 @@ class Jorge extends Application {
   }
 
   /**
-   * @return OutputInterface
+   * @return \Symfony\Component\Console\Output\OutputInterface
    */
   public function getOutput() {
     return $this->output;
   }
 
   /**
-   * Get the project root directory, plus an optional subdirectory.
+   * Return a complete path to the specified subdirectory of the project root.
    *
    * Should only be called if the command/tool requires a root path to operate.
    *
-   * @param string|NULL subdirectory to test and include
-   * @param boolean throw an exception if subdirectory doesn't exist
-   * @return string the fully qualified path
-   * @throws \DomainException code requies a path but none exists
+   * @param string|null $subdir   Subdirectory to include in the path if it exists
+   * @param boolean     $required Throw an exception if subdirectory doesn't exist
+   * @return string
+   * @throws \DomainException if code requies a path but none exists
    */
   public function getPath($subdir = NULL, $required = FALSE) {
     if ($path = $this->rootPath) {
@@ -159,8 +182,8 @@ class Jorge extends Application {
   }
 
   /**
-   * @param string the name of a tool
-   * @return Tool|NULL the tool
+   * @param string $name The name of a tool
+   * @return Tool\Tool|null
    */
   public function getTool($name) {
     if (array_key_exists($name, $this->tools) && !empty($this->tools[$name])) {
@@ -171,10 +194,10 @@ class Jorge extends Application {
   }
 
   /**
-   * Loads the contents of a config file.
+   * Loads the contents of a config file from the project root.
    *
-   * @param string filename relative to project root
-   * @param string log level if any messages are generated
+   * @param string $file  Filename relative to project root
+   * @param string $level Log level if any messages are generated
    * @return array
    */
   public function loadConfigFile($file, $level = LogLevel::WARNING) {
@@ -191,39 +214,43 @@ class Jorge extends Application {
   /**
    * Sends a message to the logger.
    *
-   * @param string|NULL what log level to use, or NULL to ignore.
-   * @param string the message
-   * @param array variable substitutions for the message
+   * @param string|null $level   What log level to use, or NULL to ignore
+   * @param string      $message May need $context interpolation
+   * @param array       $context Variable substitutions for $message
+   * @see Symfony\Component\Console\Logger\ConsoleLogger
    */
-   public function log($level, $message, array $context = []) {
-     if ($level !== NULL) {
-       $this->logger->log($level, $message, $context);
-     }
-   }
+  public function log($level, $message, array $context = []) {
+    if ($level !== NULL) {
+      $this->logger->log($level, $message, $context);
+    }
+  }
 
    /**
-    * {@inheritdoc}
-    */
-   public function run(InputInterface $input = NULL, OutputInterface $output = NULL) {
-     if (empty($input)) {
-       $input = $this->input;
-     }
-     if (empty($output)) {
-       $output = $this->output;
-     }
-     parent::run($input, $output);
-   }
-
-   /**
-    * Sanitizes a path or filename so it's safe to use.
+    * Encapsulates the parent::run() method so we don’t have to expose the
+    * instantiated IO interface objects.
     *
-    * @param string path to sanitize
-    * @return string sanitized path
+    * {@inheritDoc}
     */
-   public function sanitizePath($path) {
-     # Strip leading '/', './', or '../'.
-     $path = preg_replace('/^(\/|\.\/|\.\.\/)*/', '', $path);
-     // TODO: what else?
-     return $path;
-   }
+  public function run(InputInterface $input = NULL, OutputInterface $output = NULL) {
+    if (empty($input)) {
+      $input = $this->input;
+    }
+    if (empty($output)) {
+      $output = $this->output;
+    }
+    parent::run($input, $output);
+  }
+
+   /**
+    * Sanitizes a path or filename so it’s safe to use.
+    *
+    * @param string $path The path to sanitize
+    * @return string
+    */
+  protected function sanitizePath($path) {
+    # Strip leading '/', './', or '../'.
+    $path = preg_replace('/^(\/|\.\/|\.\.\/)*/', '', $path);
+    // TODO: what else?
+    return $path;
+  }
 }

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -12,15 +12,17 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
 class Jorge extends Application {
   private $config = [];
-  public $input;
+  private $input;
   private $logger;
-  public $output;
+  private $output;
   private $rootPath;
   private $tools;
 
@@ -119,6 +121,13 @@ class Jorge extends Application {
   }
 
   /**
+   * @return OutputInterface
+   */
+  public function getOutput() {
+    return $this->output;
+  }
+
+  /**
    * Get the project root directory, plus an optional subdirectory.
    *
    * Should only be called if the command/tool requires a root path to operate.
@@ -190,6 +199,19 @@ class Jorge extends Application {
      if ($level !== NULL) {
        $this->logger->log($level, $message, $context);
      }
+   }
+
+   /**
+    * {@inheritdoc}
+    */
+   public function run(InputInterface $input = NULL, OutputInterface $output = NULL) {
+     if (empty($input)) {
+       $input = $this->input;
+     }
+     if (empty($output)) {
+       $output = $this->output;
+     }
+     parent::run($input, $output);
    }
 
    /**

--- a/src/Tool/LandoTool.php
+++ b/src/Tool/LandoTool.php
@@ -11,11 +11,10 @@ class LandoTool extends Tool {
   /**
    * Adds the appropriate verbosity option.
    *
-   * @param int verbosity constant from OutputInterface
    * @param string lando arguments just before execution
    * @return string
    */
-  protected function applyVerbosity($verbosity, $argv = '') {
+  protected function applyVerbosity($argv = '') {
     $verbosityMap = [
       OutputInterface::VERBOSITY_QUIET        => '2>&1',
       OutputInterface::VERBOSITY_NORMAL       => '',
@@ -24,8 +23,8 @@ class LandoTool extends Tool {
       OutputInterface::VERBOSITY_DEBUG        => '-- -vvvv',
     ];
 
-    if (array_key_exists($verbosity, $verbosityMap)) {
-      return trim($argv . ' ' . $verbosityMap[$verbosity]);
+    if (array_key_exists($this->verbosity, $verbosityMap)) {
+      return trim($argv . ' ' . $verbosityMap[$this->verbosity]);
     }
     return $argv;
   }
@@ -48,7 +47,7 @@ class LandoTool extends Tool {
     }
 
     # Fail silently if the current project doesn’t use Lando.
-    $this->config = $this->getApplication()->loadConfigFile('.lando.yml', NULL);
+    $this->config = $this->jorge->loadConfigFile('.lando.yml', NULL);
     if (empty($this->config)) {
       $this->disable();
     }

--- a/src/Tool/LandoTool.php
+++ b/src/Tool/LandoTool.php
@@ -7,11 +7,19 @@ use Psr\Log\LogLevel;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 
+/**
+ * Provides a Jorge tool that can execute Lando commands.
+ *
+ * @link https://github.com/mtholyoke/jorge
+ *
+ * @author Jason Proctor <jproctor@mtholyoke.edu>
+ * @copyright 2018 Trustees of Mount Holyoke College
+ */
 class LandoTool extends Tool {
   /**
    * Adds the appropriate verbosity option.
    *
-   * @param string lando arguments just before execution
+   * @param string $argv Lando arguments just before execution
    * @return string
    */
   protected function applyVerbosity($argv = '') {
@@ -56,8 +64,8 @@ class LandoTool extends Tool {
   /**
    * Parse the output from `lando list`, which is not quite JSON.
    *
-   * @param array raw output from exec()
-   * @return array status objects
+   * @param array $lines Raw output from `lando list`
+   * @return array
    */
   protected function parseLandoList(array $lines = []) {
     # Don’t check the last line
@@ -71,9 +79,14 @@ class LandoTool extends Tool {
   }
 
   /**
-   * {@inheritdoc}
+   * Computes and saves a status.
+   *
+   * Calls `lando list`, parses the results, and then identifies if
+   * any of the results match the Lando environment we’re working in.
+   *
+   * @param string $name The name of the Lando environment
    */
-  public function updateStatus($name = NULL) {
+  public function updateStatus($name = '') {
     $exec = $this->exec('list');
     if ($exec['status'] == 0) {
       $list = $this->parseLandoList($exec['output']);

--- a/src/Tool/Tool.php
+++ b/src/Tool/Tool.php
@@ -12,20 +12,45 @@ use Symfony\Component\Console\Output\OutputInterface;
  * Base class for tools.
  *
  * Mostly an adaptation of Symfony\Component\Console\Command\Command.
+ *
+ * This class is potentially usable without subclassing it, by providing
+ * a name and an executable when it's added to the application. Overrides
+ * to some or all of the following methods make it more useful:
+ *   configure()
+ *   initialize()
+ *   updateStatus()
+ *   applyVerbosity()
+ * See further implementation details in README.md.
+ *
+ * @link https://github.com/mtholyoke/jorge
+ *
+ * @author Jason Proctor <jproctor@mtholyoke.edu>
+ * @copyright 2018 Trustees of Mount Holyoke College
  */
 class Tool {
   use JorgeTrait;
 
+  /** @var mixed $config Tool-specific configuration */
   protected $config;
+
+    /** @var boolean $enabled Indicates the tool is applicable to the current project */
   protected $enabled = FALSE;
+
+    /** @var string $executable The executable command associated with this tool */
   protected $executable;
+
+    /** @var \Symfony\Component\Console\Helper\HelperSet $helperSet */
   protected $helperSet = NULL;
+
+    /** @var string $name The name of the tool, used as an index in the application */
   protected $name;
+
+    /** @var mixed $status Tool-specific status report */
   protected $status;
 
   /**
-   * @param string|NULL the name of the tool
-   * @throws LogicException when the tool name is empty
+   * @param string|NULL $name The name of the tool
+   * @throws \Symfony\Component\Console\Exception\LogicException when the tool name is empty
    */
   public function __construct($name = NULL) {
     if (!empty($name)) {
@@ -38,10 +63,10 @@ class Tool {
   }
 
   /**
-   * Alters the arguments/options to reflect the desired verbosity setting
+   * Alters the arguments/options to include the verbosity setting.
    *
-   * @param string arguments/options for the command
-   * @return mixed arguments/options plus verbosity
+   * @param string $argv Arguments/options for the command
+   * @return string
    */
   protected function applyVerbosity($argv = '') {
     return $argv;
@@ -72,8 +97,8 @@ class Tool {
   /**
    * Executes the tool command and returns the result array and status.
    *
-   * @param string arguments and options for the command
-   * @return array the command with its output and exit status
+   * @param string $argv Arguments and options for the command
+   * @return array The command with its output and exit status
    */
   protected function exec($argv = '') {
     $command = trim($this->getExecutable() . ' ' . $argv);
@@ -87,33 +112,33 @@ class Tool {
   }
 
   /**
-   * @return Application the application
+   * @return \Symfony\Component\Console\Application
    */
   protected function getApplication() {
     return $this->application;
   }
 
   /**
-   * @return mixed the saved executable command for the tool
+   * @return string
    */
   protected function getExecutable() {
     return $this->executable;
   }
 
   /**
-   * @return mixed the name of the tool
+   * @return string
    */
   public function getName() {
     return $this->name;
   }
 
   /**
-   * @param boolean whether to call updateStatus() before returning
-   * @param mixed arguments for updateStatus() if necessary
-   * @return mixed the current status
+   * @param boolean $update Whether to call updateStatus() before returning
+   * @param mixed   $args   Arguments for updateStatus() if necessary
+   * @return mixed
    */
-  public function getStatus($refresh = FALSE, $args = NULL) {
-    if (empty($this->status) || $refresh) {
+  public function getStatus($update = FALSE, $args = NULL) {
+    if (empty($this->status) || $update) {
       $this->updateStatus($args);
     }
     return $this->status;
@@ -130,7 +155,7 @@ class Tool {
   }
 
   /**
-   * @return boolean whether the tool can be fully used
+   * @return boolean
    */
   public function isEnabled() {
     return $this->enabled;
@@ -139,8 +164,8 @@ class Tool {
   /**
    * Checks that the tool is enabled before running it.
    *
-   * @param string arguments and options for the command
-   * @return int exit status from the command
+   * @param string $argv Arguments and options for the command
+   * @return null|int
    */
   public function run($argv = '') {
     if (!$this->isEnabled()) {
@@ -153,8 +178,8 @@ class Tool {
   /**
    * Runs the tool with the given subcommands/options.
    *
-   * @param string arguments and options for the command
-   * @return int exit status from the command
+   * @param string $argv Arguments and options for the command
+   * @return null|int
    */
   public function runThis($argv = '') {
     $command = $this->applyVerbosity($argv);
@@ -171,11 +196,13 @@ class Tool {
   /**
    * Connects the tool with the application.
    *
-   * @param Application the running instance of Jorge
-   * @param string command the user would type to use this tool
-   * @return this
+   * @uses \MountHolyoke\Jorge\Helper\JorgeTrait::initializeJorge()
+   *
+   * @param \Symfony\Component\Console\Application $application
+   * @param string $executable command the user would type to use this tool
+   * @return $this
    */
-  public function setApplication(Application $application, $executable = NULL) {
+  public function setApplication(Application $application, $executable = '') {
     $this->application = $application;
     $this->helperSet = $application->getHelperSet();
     $this->initializeJorge();
@@ -194,7 +221,7 @@ class Tool {
   /**
    * Sets the command-line executable for this tool.
    *
-   * @param string a command the current user has permission to run
+   * @param string $executable A command the current user has permission to run
    * @return $this
    */
   protected function setExecutable($executable) {
@@ -231,7 +258,7 @@ class Tool {
   /**
    * Sets the current status.
    *
-   * @param mixed the status to save
+   * @param mixed $status The status to save
    * @return $this
    */
   public function setStatus($status) {
@@ -242,7 +269,7 @@ class Tool {
   /**
    * Computes and saves a status.
    *
-   * @param mixed any arguments necessary to determine the status
+   * @param mixed $args Any arguments necessary to determine the status
    */
   public function updateStatus($args = NULL) {
     $this->setStatus($this->isEnabled());

--- a/src/Tool/Tool.php
+++ b/src/Tool/Tool.php
@@ -162,7 +162,7 @@ class Tool {
     $result = $this->exec($command);
 
     if ($this->verbosity != OutputInterface::VERBOSITY_QUIET) {
-      $this->jorge->output->writeln(implode("\n", $result['output']));
+      $this->writeln($result['output']);
     }
 
     return $result['status'];

--- a/src/Tool/Tool.php
+++ b/src/Tool/Tool.php
@@ -6,7 +6,6 @@ use MountHolyoke\Jorge\Helper\JorgeTrait;
 use Psr\Log\LogLevel;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\LogicException;
-use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -127,7 +126,7 @@ class Tool {
    * usually the first opportunity to determine whether the tool is enabled,
    * meaning it is used in the current project being supported by Jorge.
    */
-  protected function initialize(InputInterface $input, OutputInterface $output) {
+  protected function initialize() {
   }
 
   /**
@@ -179,7 +178,7 @@ class Tool {
   public function setApplication(Application $application, $executable = NULL) {
     $this->application = $application;
     $this->helperSet = $application->getHelperSet();
-    $this->initializeJorge($application->input, $application->output);
+    $this->initializeJorge();
 
     if (empty($this->getExecutable())) {
       if (empty($executable)) {
@@ -188,7 +187,7 @@ class Tool {
       $this->setExecutable($executable);
     }
 
-    $this->initialize($application->input, $application->output);
+    $this->initialize();
     return $this;
   }
 


### PR DESCRIPTION
This branch adds a [PHP trait](http://php.net/manual/en/language.oop5.traits.php), `JorgeTrait`, which provides some common things to all the commands and tools that use it:

- An instance variable `$this->jorge` which points to the actual running application object

- An instance variable `$this->verbosity` which makes it easy to get the verbosity the user specified on the command line

- A method `$this->log()` that hands things to the application’s built-in logger (it’s fancy, with interpolation and log levels that know about verbosity)

- A method `$this->writeln()` that dumps things directly to Jorge’s output interface without going through the logger, which is not really recommended most of the time, but it’s appropriate for things like echoing the results of a command

It updates the existing commands (except `honk`) and plugins to have and use the trait.

Also it puts standard [phpDoc](https://docs.phpdoc.org/) on everything. I’m not really convinced of its full utility, but it’s definitely better than not having any structure at all.

It runs on my local (and I haven’t written any more rigorous tests yet), so I’m going to merge this immediately and call it a new release. 