### PR TITLE
Git Tool

### DIFF
--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -139,7 +139,6 @@ class ResetCommand extends Command {
    * Defines and runs the sequence necessary to reset a Drupal 8 site.
    *
    * Assumes Git, Composer, and Lando for a Pantheon-hosted site.
-   * @todo Implement a Git tool
    * @todo Construct a real return value
    * @todo Refactor into a DDL?
    *
@@ -190,35 +189,5 @@ class ResetCommand extends Command {
       $drushInput = new ArrayInput($step);
       $drush->run($drushInput, $this->jorge->getOutput());
     }
-  }
-
-  /**
-   * Performs a step, with appropriate verbosity.
-   *
-   * @todo Fix the verbosity to be consistent with Tool
-   * @todo Refactor to receive a DDL?
-   *
-   * @param string $step The assembled command to execute
-   * @return null|int
-   * @throws \Symfony\Component\Console\Exception\RuntimeException
-   */
-  private function processStep($step) {
-    $this->log(LogLevel::NOTICE, '$ ' . $step);
-    $result = '';
-
-    if ($this->verbosity >= OutputInterface::VERBOSITY_VERBOSE) {
-      system($step, $status);
-    } else {
-      exec($step, $result, $status);
-    }
-    if ($status) {
-      $error = 'Command exited with nonzero status.';
-      if (is_array($result)) {
-        $result = implode("\n", $result);
-      }
-      $message = sprintf("> %s\n%s\n%s", $step, $error, $result);
-      throw new RuntimeException($message, $status);
-    }
-    return $status;
   }
 }

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -6,6 +6,7 @@ use MountHolyoke\Jorge\Command\DrushCommand;
 use MountHolyoke\Jorge\Command\HonkCommand;
 use MountHolyoke\Jorge\Command\ResetCommand;
 use MountHolyoke\Jorge\Tool\ComposerTool;
+use MountHolyoke\Jorge\Tool\GitTool;
 use MountHolyoke\Jorge\Tool\LandoTool;
 use MountHolyoke\Jorge\Tool\Tool;
 use Psr\Log\LogLevel;
@@ -92,6 +93,7 @@ class Jorge extends Application {
     $this->add(new ResetCommand());
 
     $this->addTool(new ComposerTool());
+    $this->addTool(new GitTool());
     $this->addTool(new LandoTool());
   }
 

--- a/src/Tool/GitTool.php
+++ b/src/Tool/GitTool.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace MountHolyoke\Jorge\Tool;
+
+use MountHolyoke\Jorge\Tool\Tool;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Provides a Jorge tool that can execute Git commands.
+ *
+ * @link https://github.com/mtholyoke/jorge
+ *
+ * @author Jason Proctor <jproctor@mtholyoke.edu>
+ * @copyright 2018 Trustees of Mount Holyoke College
+ */
+class GitTool extends Tool {
+  /**
+   * {@inheritDoc}
+   */
+  protected function applyVerbosity($argv = '') {
+    $flag = '';
+    switch ($this->verbosity) {
+      case OutputInterface::VERBOSITY_QUIET:
+      case OutputInterface::VERBOSITY_NORMAL:
+      default:
+        break;
+      case OutputInterface::VERBOSITY_VERBOSE:
+        $flag = '-v';
+        break;
+      case OutputInterface::VERBOSITY_VERY_VERBOSE:
+      case OutputInterface::VERBOSITY_DEBUG:
+        $flag = '-vv';
+        break;
+    }
+    return trim($argv . ' ' . $flag);
+  }
+
+  /**
+   * Establishes the `git` tool.
+   */
+  protected function configure() {
+    $this->setName('git');
+    $this->setStatus((object)['clean' => FALSE]);
+  }
+
+  /**
+   * Enables the `git` tool if we have an executable and the project is a git repo
+   */
+  protected function initialize() {
+    if (!empty($this->getExecutable())) {
+      chdir($this->jorge->getPath());
+      $exec = $this->exec('status 2>&1');
+      if ($exec['status'] == 0) {
+        $this->enable();
+        $this->updateStatus($exec['output']);
+      }
+    }
+  }
+
+  /**
+   * Determines where there are changes to be staged or committed.
+   */
+  public function updateStatus($output = []) {
+    if (empty($output)) {
+      $exec = $this->exec('status 2>&1');
+      $output = $exec['output'];
+    }
+    $status = $this->getStatus();
+    $status->clean = (strpos(end($output), 'nothing to commit') !== FALSE);
+    $this->setStatus($status);
+  }
+}


### PR DESCRIPTION
This branch adds a Git tool, basically a PHP wrapper around the command-line executable.

It turns out there is no actively maintained pure PHP implementation of Git.
- [glip](https://github.com/patrikf/glip) has been forked well over 100 times but is basically abandoned by everyone. I found [one from ModulusDev](https://github.com/ModulusDev/glip) that had some refactoring with PRs up into 2016, but from far older code, and it was [forked by AlexFBP](https://github.com/AlexFBP/glip) last year to add some documentation.
- [GitBundle](https://github.com/xaav/XaavGitBundle) updated glip to use Symfony2 in 2011.
- [php-git](https://github.com/libgit2/php-git) is only unmaintained for 4 years, but it’s a PHP binding (written in C) to libgit2.so. While at least _that_ is being maintained, I’m certain I don’t want to figure out how to get the PHP binding up to date and everything installed on an arbitrary workstation.

Writing a new one in PHP 7 (and Symfony? Laravel?) might actually be really interesting. But Jorge ain’t got time for that.