### PR TITLE
Drupal 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,22 @@ Jorge is an experimental command-line tool for managing the complex interaction 
 
 This is not a thing to `require` within a project; it’s a tool for your workstation. Composer facilitates that with `composer global require`, but that command is somewhat flawed in the way it manages things, so we prefer [`cgr`](https://pantheon.io/blog/fixing-composer-global-command).
 
-To install it, run `composer global require consolidation/cgr` and it will be added in the `.composer` directory off your home directory. You will also need to tell the system that you’re adding executables to a new place. In your home directory, there can be a file named `.profile` which is run every time you log in. Edit that file (create it if it doesn’t exist) and add a line at the end:
+To install it, run `composer global require consolidation/cgr` and it will be added in the `.composer` directory off your home directory. You will also need to tell the system that you’re adding executables to a new place. In your home directory, there can be a file named `.bash_profile` or `.profile` which is run every time you log in. Edit that file (create one if neither exists) and add a line at the end:
 ```bash
 export PATH="$PATH:~/.composer/vendor/bin"
 ```
 
-In order for it to take effect, you can either log out and back in, or run `source .profile`. You can test that it worked by running `which cgr`; it should tell you `/Users/{you}/.composer/vendor/bin/cgr`.
+In order for the new `PATH` to take effect, you can either log out and back in, or run `source .bash_profile` (or `source .profile`). You can test that it worked by running `cgr --help`; it should give you help instead of an error message.
 
 After all that, you should be able to run `cgr mtholyoke/jorge`. If it is successfully installed, `jorge --version` will report “Can’t find project root” and a version.
 
 
 ### For Development: Install with Git
 
-You can also clone this repo for development and run Jorge directly from that copy. Rather than adding `~/Projects/jorge/bin` to your path, I recommend making a symlink to _`{...}`_`/bin/jorge` (the actual program) from `/usr/local/bin` or some other location already in your path.
+You can also clone this repo for development and run Jorge directly from that copy. Rather than adding `~/Projects/jorge/bin` (or whatever your Projects directory is; run `pwd` to check) to your path, I recommend making a symlink to `bin/jorge` (the actual program) from `/usr/local/bin` or some other location already in your path:
+```bash
+ln -s ~/Projects/jorge/bin/jorge /usr/local/bin/jorge
+```
 
 If you're going to do any development, also run `bin/setup.sh` once to install the standard Git hooks.
 
@@ -32,11 +35,11 @@ Jorge has no global configuration; it works on the project level only.
 
 The project’s root directory should contain a subdirectory `.jorge`, which should have a file `config.yml`. Samples are included in Jorge’s own `.jorge` directory.
 
-In `.jorge/config.yml`, you **must** have the key `appType`. Currently, only `drupal8` and `jorge` are recognized as values.
+In `.jorge/config.yml`, you **must** have the key `appType`. Currently, only `drupal7`, `drupal8`, and `jorge` are recognized as values.
 
 Optionally, you may also have the key `include_config`, which specifies a list of additional configuration files to include from the `.jorge` directory, to be loaded in the order specified. Values in those files will override any previously loaded settings, including the main `config.yml`.
 
-### Drupal 8 Configuration
+### Drupal 7 or 8 Configuration
 
 A config file may include the key `reset`, which contains a block that provides any of five optional parameters to the `reset` command (described below):
 - `branch  ` - Which Git branch to reset your current codebase to (default `master`)
@@ -70,9 +73,7 @@ reset:
 
 ### `jorge drush `_`{drush-command}`_
 
-Runs `lando drush `_`{drush-command}`_ inside the `web` directory (so it has access to Drupal), regardless of whether you’re currently in that directory.
-
-Starts Lando if it is not already running.
+In a Composer-powered Drupal 8 project, `lando drush `_`{drush-command}`_ needs to be run inside the `web` directory (so it has access to Drupal), regardless of whether you’re currently in that directory. This command runs it from outside that directory, (after starting Lando if it’s not already running).
 
 Accepts the `-y`/`--yes` option natively, but other Drush options need to be escaped. See `jorge help drush` for details.
 

--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -68,10 +68,7 @@ only apply to Drush, you can escape -v/--verbose as above.
       return;
     }
     chdir($webdir);
-    if (!$lando->getStatus()->running) {
-      $lando->run('start');
-      $lando->updateStatus();
-    }
+    $lando->requireStarted();
     return $lando->run($drush);
   }
 

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -159,10 +159,7 @@ class ResetCommand extends Command {
     }
     $git->run(['checkout', $this->params['branch']]);
     $git->run(['pull']);
-    if (!$lando->getStatus()->running) {
-      $lando->run('start');
-      $lando->updateStatus();
-    }
+    $lando->requireStarted();
     $lando_pull = 'pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
     if ($this->params['rsync']) {
       $lando_pull .= ' --rsync';
@@ -211,10 +208,7 @@ class ResetCommand extends Command {
     $git->run(['checkout', $this->params['branch']]);
     $git->run(['pull']);
     $composer->run(['command' => 'install']);
-    if (!$lando->getStatus()->running) {
-      $lando->run('start');
-      $lando->updateStatus();
-    }
+    $lando->requireStarted();
     $lando_pull = 'pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
     if ($this->params['rsync']) {
       $lando_pull .= ' --rsync';

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -114,6 +114,9 @@ class ResetCommand extends Command {
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
     switch ($this->appType) {
+      case 'drupal7':
+        return $this->executeDrupal7();
+        break;
       case 'drupal8':
         return $this->executeDrupal8();
         break;
@@ -133,6 +136,56 @@ class ResetCommand extends Command {
         break;
     }
     return 1;
+  }
+
+  /**
+   * Defines and runs the sequence necessary to reset a Drupal 7 site.
+   *
+   * Assumes Git and Lando for a Pantheon-hosted site.
+   * @todo Implement tools for Git
+   * @todo Construct a real return value
+   * @todo Refactor into a DDL?
+   *
+   * @return null|int
+   */
+  protected function executeDrupal7() {
+    $lando = $this->jorge->getTool('lando');
+
+    # Do some stuff in the project root
+    chdir($this->jorge->getPath());
+    if (!$lando->getStatus()->running) {
+      $lando->run('start');
+    }
+    $steps = [
+      'git checkout ' . $this->params['branch'],
+      'git pull',
+    ];
+    foreach ($steps as $step) {
+      $this->processStep($step);
+    }
+    $lando_pull = 'pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
+    if ($this->params['rsync']) {
+      $lando_pull .= ' --rsync';
+    }
+    $lando->run($lando_pull);
+
+    $drush = $this->jorge->find('drush');
+    $drushSequence = [['drush_command' => ['cc', 'all']]];
+    if (!empty($this->params['username']) && !empty($this->params['password'])) {
+      $drushSequence[] = [
+        'drush_command' => [
+          'upwd',
+          $this->params['username'],
+          '--password="' . $this->params['password'] . '"',
+        ],
+      ];
+    }
+    $drushSequence[] = ['drush_command' => ['cc', 'all']];
+
+    foreach ($drushSequence as $step) {
+      $drushInput = new ArrayInput($step);
+      $drush->run($drushInput, $this->jorge->getOutput());
+    }
   }
 
   /**

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -153,15 +153,15 @@ class ResetCommand extends Command {
 
     # Do some stuff in the project root
     chdir($this->jorge->getPath());
+    if (!$git->getStatus()->clean) {
+      $this->log(LogLevel::ERROR, "Working directory not clean. Aborting.");
+      return;
+    }
+    $git->run(['checkout', $this->params['branch']]);
+    $git->run(['pull']);
     if (!$lando->getStatus()->running) {
       $lando->run('start');
-    }
-    $steps = [
-      'git checkout ' . $this->params['branch'],
-      'git pull',
-    ];
-    foreach ($steps as $step) {
-      $this->processStep($step);
+      $lando->updateStatus();
     }
     $lando_pull = 'pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
     if ($this->params['rsync']) {

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -38,9 +38,9 @@ class ResetCommand extends Command {
     $this
       ->setName('reset')
       ->setDescription('Aligns code, database, and files to a specified state')
-      ->addOption('branch',   'b', InputOption::VALUE_OPTIONAL, 'Git branch to use', 'master')
-      ->addOption('database', 'd', InputOption::VALUE_OPTIONAL, 'Environment to load database from', 'dev')
-      ->addOption('files',    'f', InputOption::VALUE_OPTIONAL, 'Environment to copy files from', 'dev')
+      ->addOption('branch',   'b', InputOption::VALUE_OPTIONAL, 'Git branch to use <fg=yellow>[default: "master"]</>')
+      ->addOption('database', 'd', InputOption::VALUE_OPTIONAL, 'Environment to load database from <fg=yellow>[default: "dev"]</>')
+      ->addOption('files',    'f', InputOption::VALUE_OPTIONAL, 'Environment to copy files from <fg=yellow>[default: "dev"]</>')
       ->addOption('username', 'u', InputOption::VALUE_OPTIONAL, 'Admin account to have local password set')
       ->addOption('password', 'p', InputOption::VALUE_OPTIONAL, 'Local password for admin account')
       ->setHelp('This command updates the local git environment to the latest master, copies the latest database and files from the specified environment on Pantheon, and imports the default config suitable for a hands-on development instance.')
@@ -149,6 +149,7 @@ class ResetCommand extends Command {
    * @return null|int
    */
   protected function executeDrupal7() {
+    $git = $this->jorge->getTool('git');
     $lando = $this->jorge->getTool('lando');
 
     # Do some stuff in the project root

--- a/src/Tool/GitTool.php
+++ b/src/Tool/GitTool.php
@@ -4,7 +4,6 @@ namespace MountHolyoke\Jorge\Tool;
 
 use MountHolyoke\Jorge\Tool\Tool;
 use Psr\Log\LogLevel;
-use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**

--- a/src/Tool/LandoTool.php
+++ b/src/Tool/LandoTool.php
@@ -90,6 +90,16 @@ class LandoTool extends Tool {
   }
 
   /**
+   * Ensures that Lando is started in the current project.
+   */
+  public function requireStarted() {
+    if (!$this->getStatus(TRUE)->running) {
+      $this->run('start');
+      $this->updateStatus();
+    }
+  }
+
+  /**
    * Computes and saves a status.
    *
    * Calls `lando list`, parses the results, and then identifies if


### PR DESCRIPTION

This branch adds support for `jorge reset` on the main College website (Drupal 7 at Pantheon). It might not work for any other Drupal 7s, but I only need it for the one.

Also it fixes a major bug in the Reset command: the _default_ command-line options were overriding the config file, when it should have only been the user-supplied command-line options that could do so.
