### PR TITLE
Testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "composer/composer": "^1.6"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7"
+    "phpunit/phpunit": "^7",
+    "spatie/temporary-directory": "^1.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
     "symfony/yaml": "^4.0",
     "composer/composer": "^1.6"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^7"
+  },
   "autoload": {
     "psr-4": {
       "MountHolyoke\\Jorge\\": "src/"
@@ -20,5 +23,8 @@
   },
   "bin": [
     "bin/jorge"
-  ]
+  ],
+  "scripts": {
+    "phpunit": "vendor/bin/phpunit"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
   },
   "autoload": {
     "psr-4": {
-      "MountHolyoke\\Jorge\\": "src/"
+      "MountHolyoke\\Jorge\\": "src/",
+      "MountHolyoke\\JorgeTests\\": "tests/"
     }
   },
   "bin": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "65d00c7e6d861469aec965adfe9d6102",
+    "content-hash": "4c8aff49b93c2bafdad9eb86ac893ef2",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -2213,6 +2213,52 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "spatie/temporary-directory",
+            "version": "1.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/temporary-directory.git",
+                "reference": "e3da5b7a00c6610bc0b18480815fe09adf73383b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/temporary-directory/zipball/e3da5b7a00c6610bc0b18480815fe09adf73383b",
+                "reference": "e3da5b7a00c6610bc0b18480815fe09adf73383b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "5.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TemporaryDirectory\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Easily create, use and destroy temporary directories",
+            "homepage": "https://github.com/spatie/temporary-directory",
+            "keywords": [
+                "spatie",
+                "temporary-directory"
+            ],
+            "time": "2017-09-11T08:51:13+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "3ccbb899cbb290d60545a7653e618be5",
+    "content-hash": "65d00c7e6d861469aec965adfe9d6102",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -849,7 +849,1462 @@
             "time": "2018-02-19T20:08:53+00:00"
         }
     ],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "reference": "185b8868aa9bf7159f5f953ed5afb2d7fcdc3bda",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "^6.2.3",
+                "squizlabs/php_codesniffer": "^3.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2017-07-22T11:58:36+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.0",
+                "doctrine/common": "^2.6",
+                "phpunit/phpunit": "^4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                },
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-10-19T19:58:43+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-phar": "*",
+                "phar-io/version": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "time": "2017-03-05T18:14:27+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "time": "2017-03-05T17:38:23+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2017-09-11T18:02:19+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "4.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94fd0001232e47129dd3504189fa1c7225010d08",
+                "reference": "94fd0001232e47129dd3504189fa1c7225010d08",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "phpdocumentor/reflection-common": "^1.0.0",
+                "phpdocumentor/type-resolver": "^0.4.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "doctrine/instantiator": "~1.0.5",
+                "mockery/mockery": "^1.0",
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2017-11-30T07:14:17+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2017-07-14T14:27:02+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "1.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2018-02-19T10:16:54+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^1.4.2",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-token-stream": "^3.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0.1",
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0.1",
+                "theseer/tokenizer": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-xdebug": "^2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-02-02T07:01:41+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2017-11-27T13:52:08+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21T13:50:34+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2018-02-01T13:07:23+00:00"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2018-02-01T13:16:43+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "7.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/536f4d853c12d8189963435088e8ff7c0daeab2e",
+                "reference": "536f4d853c12d8189963435088e8ff7c0daeab2e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.6.1",
+                "phar-io/manifest": "^1.0.1",
+                "phar-io/version": "^1.0",
+                "php": "^7.1",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^6.0.1",
+                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-text-template": "^1.2.1",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
+                "sebastian/comparator": "^2.1",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^3.1",
+                "sebastian/exporter": "^3.1",
+                "sebastian/global-state": "^2.0",
+                "sebastian/object-enumerator": "^3.0.3",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0.1"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
+            },
+            "suggest": {
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^2.0"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2018-03-26T07:36:48+00:00"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.5",
+                "php": "^7.1",
+                "phpunit/php-text-template": "^1.2.1",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2018-02-15T05:27:38+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^2.0 || ^3.0",
+                "sebastian/exporter": "^3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2018-02-01T13:46:46+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "time": "2018-02-01T13:45:15+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2017-07-01T08:51:00+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/234199f4528de6d12aaa58b612e98f7d36adb937",
+                "reference": "234199f4528de6d12aaa58b612e98f7d36adb937",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2017-04-03T13:19:02+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2017-04-27T15:39:26+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "reference": "7cfd9e65d11ffb5af41198476395774d4c8a84c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.1.1",
+                "sebastian/recursion-context": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-08-03T12:35:26+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/773f97c67f28de00d397be301821b06708fca0be",
+                "reference": "773f97c67f28de00d397be301821b06708fca0be",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-29T09:07:27+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2017-03-03T06:23:57+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-10-03T07:35:21+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
+                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2018-01-29T19:49:41+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": [],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,7 +13,12 @@
 
   <filter>
     <whitelist>
-      <directory>../src</directory>
+      <directory>src</directory>
     </whitelist>
   </filter>
+
+  <!--logging>
+    <log type="coverage-clover" target="tests/coverage.xml"/>
+    <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+  </logging-->
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,10 +2,18 @@
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
-  bootstrap="vendor/autoload.php">
+  bootstrap="vendor/autoload.php"
+  colors="true">
+
   <testsuites>
-    <testsuite name="Main Tests">
+    <testsuite name="Full Jorge Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+
+  <filter>
+    <whitelist>
+      <directory>../src</directory>
+    </whitelist>
+  </filter>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0/phpunit.xsd"
+  bootstrap="vendor/autoload.php">
+  <testsuites>
+    <testsuite name="Main Tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -72,10 +72,10 @@ class Jorge extends Application {
     $this->setVersion('0.4.0');
 
     if ($this->rootPath = $this->findRootPath()) {
-      $this->logger->notice('Project root: {%root}', ['%root' => $this->rootPath]);
+      $this->log(LogLevel::NOTICE, 'Project root: {%root}', ['%root' => $this->rootPath]);
       $this->config = $this->loadConfigFile('.jorge' . DIRECTORY_SEPARATOR . 'config.yml', LogLevel::ERROR);
     } else {
-      $this->logger->warning('Can’t find project root');
+      $this->log(LogLevel::WARNING, 'Can’t find project root');
     }
 
     // If the config file specifies additional config, load that too.
@@ -85,7 +85,7 @@ class Jorge extends Application {
       }
       foreach ($this->config['include_config'] as $file) {
         $configFile = '.jorge' . DIRECTORY_SEPARATOR . $file;
-        $this->logger->debug('Including config file {%filename}', ['%filename' => $configFile]);
+        $this->log(LogLevel::DEBUG, 'Including config file {%filename}', ['%filename' => $configFile]);
         $addition = $this->loadConfigFile($configFile);
         $this->config = array_merge_recursive($this->config, $addition);
       }
@@ -190,7 +190,7 @@ class Jorge extends Application {
       if ($required) {
         throw new \DomainException('Subdirectory "' . $subdir . '" is required.');
       } else {
-        $this->logger->warning('No "{%subdir}" subdirectory in root path', ['%subdir' => $subdir]);
+        $this->log(LogLevel::WARNING, 'No "{%subdir}" subdirectory in root path', ['%subdir' => $subdir]);
       }
     } elseif ($required) {
       throw new \DomainException('Project root path is required.');
@@ -206,7 +206,7 @@ class Jorge extends Application {
     if (array_key_exists($name, $this->tools) && !empty($this->tools[$name])) {
       return $this->tools[$name];
     }
-    $this->logger->warning('Can’t get tool "{%tool}"', ['%tool' => $name]);
+    $this->log(LogLevel::WARNING, 'Can’t get tool "{%tool}"', ['%tool' => $name]);
     return NULL;
   }
 

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -49,7 +49,7 @@ class Jorge extends Application {
   /** @var string $rootPath The fully qualified path of the project root */
   private $rootPath;
 
-  /** @var array $tools The instances of Tool\Tool available to this app. */
+  /** @var Tool\Tool[] $tools The instances of Tool\Tool available to this app. */
   private $tools;
 
   /**
@@ -72,7 +72,10 @@ class Jorge extends Application {
     $this->setVersion('0.4.0');
 
     if ($this->rootPath = $this->findRootPath()) {
+      $this->logger->notice('Project root: {%root}', ['%root' => $this->rootPath]);
       $this->config = $this->loadConfigFile('.jorge/config.yml', LogLevel::ERROR);
+    } else {
+      $this->logger->warning('Can’t find project root');
     }
 
     // If the config file specifies additional config, load that too.
@@ -116,22 +119,29 @@ class Jorge extends Application {
   }
 
   /**
+   * Gets all tools currently attached.
+   *
+   * @return Tool\Tool[] Array of Tool instances
+   */
+  public function allTools() {
+    return $this->tools;
+  }
+
+  /**
    * Traverses up the directory tree from current location until it finds the
    * project root, defined as a directory that contains a .jorge directory.
    *
    * @return string|false full path to document root, or FALSE if none found
    */
-  private function findRootPath() {
+  private static function findRootPath() {
     $wd = explode('/', getcwd());
     while (!empty($wd) && $cwd = implode('/', $wd)) {
       $path = $cwd . '/.jorge';
       if (is_dir($path) && is_readable($path)) {
-        $this->logger->notice('Project root: {%root}', ['%root' => $cwd]);
         return $cwd;
       }
       array_pop($wd);
     }
-    $this->logger->warning('Can’t find project root');
     return FALSE;
   }
 
@@ -252,7 +262,7 @@ class Jorge extends Application {
     * @param string $path The path to sanitize
     * @return string
     */
-  protected function sanitizePath($path) {
+  protected static function sanitizePath($path) {
     # Strip leading '/', './', or '../'.
     $path = preg_replace('/^(\/|\.\/|\.\.\/)*/', '', $path);
     // TODO: what else?

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -172,7 +172,7 @@ class Jorge extends Application {
    *
    * @param string|null $subdir   Subdirectory to include in the path if it exists
    * @param boolean     $required Throw an exception if subdirectory doesn't exist
-   * @return string
+   * @return string|null
    * @throws \DomainException if code requies a path but none exists
    */
   public function getPath($subdir = NULL, $required = FALSE) {
@@ -191,9 +191,10 @@ class Jorge extends Application {
         }
       }
       return $path;
-    } else {
+    } elseif ($required) {
       throw new \DomainException('Project root path is required.');
     }
+    return NULL;
   }
 
   /**

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -181,18 +181,17 @@ class Jorge extends Application {
   public function getPath($subdir = NULL, $required = FALSE) {
     if ($path = $this->rootPath) {
       $subdir = $this->sanitizePath($subdir);
-      if (!empty($subdir)) {
-        if (is_dir($path . DIRECTORY_SEPARATOR . $subdir)) {
-          $path .= DIRECTORY_SEPARATOR . $subdir;
-        } else {
-          if ($required) {
-            throw new \DomainException('Subdirectory "' . $subdir . '" is required.');
-          } else {
-            $this->logger->warning('No "{%subdir}" subdirectory in root path', ['%subdir' => $subdir]);
-          }
-        }
+      if (empty($subdir)) {
+        return $path;
       }
-      return $path;
+      if (is_dir($path . DIRECTORY_SEPARATOR . $subdir)) {
+        return $path . DIRECTORY_SEPARATOR . $subdir;
+      }
+      if ($required) {
+        throw new \DomainException('Subdirectory "' . $subdir . '" is required.');
+      } else {
+        $this->logger->warning('No "{%subdir}" subdirectory in root path', ['%subdir' => $subdir]);
+      }
     } elseif ($required) {
       throw new \DomainException('Project root path is required.');
     }

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -73,7 +73,7 @@ class Jorge extends Application {
 
     if ($this->rootPath = $this->findRootPath()) {
       $this->logger->notice('Project root: {%root}', ['%root' => $this->rootPath]);
-      $this->config = $this->loadConfigFile('.jorge/config.yml', LogLevel::ERROR);
+      $this->config = $this->loadConfigFile('.jorge' . DIRECTORY_SEPARATOR . 'config.yml', LogLevel::ERROR);
     } else {
       $this->logger->warning('Can’t find project root');
     }
@@ -84,7 +84,7 @@ class Jorge extends Application {
         $this->config['include_config'] = [ $this->config['include_config'] ];
       }
       foreach ($this->config['include_config'] as $file) {
-        $configFile = '.jorge/' . $file;
+        $configFile = '.jorge' . DIRECTORY_SEPARATOR . $file;
         $this->logger->debug('Including config file {%filename}', ['%filename' => $configFile]);
         $addition = $this->loadConfigFile($configFile);
         $this->config = array_merge_recursive($this->config, $addition);
@@ -148,10 +148,13 @@ class Jorge extends Application {
   /**
    * Return a parameter from configuration.
    *
-   * @param string $key     The key to get from config
-   * @param mixed  $default The value to return if key not present
+   * @param string|null $key     The key to get from config, NULL for all
+   * @param mixed       $default The value to return if key not present
    */
-  public function getConfig($key, $default = NULL) {
+  public function getConfig($key = NULL, $default = NULL) {
+    if ($key === NULL) {
+      return $this->config;
+    }
     if (array_key_exists($key, $this->config)) {
       return $this->config[$key];
     }

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -79,7 +79,7 @@ class Jorge extends Application {
     }
 
     // If the config file specifies additional config, load that too.
-    if (array_key_exists('include_config', $this->config)) {
+    if (!empty($this->config) && array_key_exists('include_config', $this->config)) {
       if (!is_array($this->config['include_config'])) {
         $this->config['include_config'] = [ $this->config['include_config'] ];
       }
@@ -222,7 +222,8 @@ class Jorge extends Application {
     $pathfile = $this->rootPath . DIRECTORY_SEPARATOR . $file;
     if (is_file($pathfile) && is_readable($pathfile)) {
       // TODO: sanitize values?
-      return Yaml::parseFile($pathfile);
+      $parsed = Yaml::parseFile($pathfile) ?: [];
+      return $parsed;
     }
     $this->log($level, 'Can’t read config file {%filename}', ['%filename' => $pathfile]);
     return [];
@@ -234,7 +235,7 @@ class Jorge extends Application {
    * @param string|null $level   What log level to use, or NULL to ignore
    * @param string      $message May need $context interpolation
    * @param array       $context Variable substitutions for $message
-   * @see Symfony\Component\Console\Logger\ConsoleLogger
+   * @see \Symfony\Component\Console\Logger\ConsoleLogger
    */
   public function log($level, $message, array $context = []) {
     if ($level !== NULL) {

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -134,9 +134,9 @@ class Jorge extends Application {
    * @return string|false full path to document root, or FALSE if none found
    */
   private static function findRootPath() {
-    $wd = explode('/', getcwd());
-    while (!empty($wd) && $cwd = implode('/', $wd)) {
-      $path = $cwd . '/.jorge';
+    $wd = explode(DIRECTORY_SEPARATOR, getcwd());
+    while (!empty($wd) && $cwd = implode(DIRECTORY_SEPARATOR, $wd)) {
+      $path = $cwd . DIRECTORY_SEPARATOR . '.jorge';
       if (is_dir($path) && is_readable($path)) {
         return $cwd;
       }
@@ -179,8 +179,8 @@ class Jorge extends Application {
     if ($path = $this->rootPath) {
       $subdir = $this->sanitizePath($subdir);
       if (!empty($subdir)) {
-        if (is_dir($path . '/' . $subdir)) {
-          $path .= '/' . $subdir;
+        if (is_dir($path . DIRECTORY_SEPARATOR . $subdir)) {
+          $path .= DIRECTORY_SEPARATOR . $subdir;
         } else {
           $s = ['%subdir' => $subdir];
           if ($required) {
@@ -218,7 +218,7 @@ class Jorge extends Application {
    */
   public function loadConfigFile($file, $level = LogLevel::WARNING) {
     $file = $this->sanitizePath($file);
-    $pathfile = $this->rootPath . '/' . $file;
+    $pathfile = $this->rootPath . DIRECTORY_SEPARATOR . $file;
     if (is_file($pathfile) && is_readable($pathfile)) {
       // TODO: sanitize values?
       return Yaml::parseFile($pathfile);
@@ -265,6 +265,7 @@ class Jorge extends Application {
     */
   protected static function sanitizePath($path) {
     # Strip leading '/', './', or '../'.
+    // TODO: DIRECTORY_SEPARATOR instead of /
     $path = preg_replace('/^(\/|\.\/|\.\.\/)*/', '', $path);
     // TODO: what else?
     return $path;

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -111,8 +111,8 @@ class Jorge extends Application {
    */
   public function addTool(Tool $tool, $executable = '') {
     $name = $tool->setApplication($this, $executable)->getName();
-    if (empty($name)) {
-      throw new LogicException(sprintf('The tool defined in "%s" has an invalid or empty name.', get_class($tool)));
+    if (!empty($this->tools) && array_key_exists($name, $this->tools)) {
+      throw new LogicException(sprintf('The tool defined in "%s" duplicates an existing tool’s name.', get_class($tool)));
     }
     $this->tools[$name] = $tool;
     return $tool;
@@ -256,7 +256,7 @@ class Jorge extends Application {
     if (empty($output)) {
       $output = $this->output;
     }
-    parent::run($input, $output);
+    return parent::run($input, $output);
   }
 
   /**

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -242,12 +242,12 @@ class Jorge extends Application {
     }
   }
 
-   /**
-    * Encapsulates the parent::run() method so we don’t have to expose the
-    * instantiated IO interface objects.
-    *
-    * {@inheritDoc}
-    */
+  /**
+   * Encapsulates the parent::run() method so we don’t have to expose the
+   * instantiated IO interface objects.
+   *
+   * {@inheritDoc}
+   */
   public function run(InputInterface $input = NULL, OutputInterface $output = NULL) {
     if (empty($input)) {
       $input = $this->input;
@@ -258,16 +258,17 @@ class Jorge extends Application {
     parent::run($input, $output);
   }
 
-   /**
-    * Sanitizes a path or filename so it’s safe to use.
-    *
-    * @param string $path The path to sanitize
-    * @return string
-    */
+  /**
+   * Sanitizes a path or filename so it’s safe to use.
+   *
+   * @param string $path The path to sanitize
+   * @return string
+   */
   protected static function sanitizePath($path) {
+    $path = trim($path);
     # Strip leading '/', './', or '../'.
-    // TODO: DIRECTORY_SEPARATOR instead of /
-    $path = preg_replace('/^(\/|\.\/|\.\.\/)*/', '', $path);
+    $ds = (DIRECTORY_SEPARATOR == '#') ? '\#' : DIRECTORY_SEPARATOR;
+    $path = preg_replace('#^(\.{0,2}' . $ds . '\s*)*#', '', $path);
     // TODO: what else?
     return $path;
   }

--- a/src/Jorge.php
+++ b/src/Jorge.php
@@ -185,11 +185,10 @@ class Jorge extends Application {
         if (is_dir($path . DIRECTORY_SEPARATOR . $subdir)) {
           $path .= DIRECTORY_SEPARATOR . $subdir;
         } else {
-          $s = ['%subdir' => $subdir];
           if ($required) {
-            throw new \DomainException('Subdirectory "{%subdir}" is required.', $s);
+            throw new \DomainException('Subdirectory "' . $subdir . '" is required.');
           } else {
-            $this->logger->warning('No "{%subdir}" subdirectory in root path', $s);
+            $this->logger->warning('No "{%subdir}" subdirectory in root path', ['%subdir' => $subdir]);
           }
         }
       }

--- a/src/Tool/ComposerTool.php
+++ b/src/Tool/ComposerTool.php
@@ -107,7 +107,7 @@ class ComposerTool extends Tool {
     if (($rootPath = $this->jorge->getPath()) === NULL) {
       return;
     }
-    $composerJson = $rootPath . '/composer.json';
+    $composerJson = $rootPath . DIRECTORY_SEPARATOR . 'composer.json';
     if (!is_file($composerJson)) {
       return;
     }

--- a/src/Tool/ComposerTool.php
+++ b/src/Tool/ComposerTool.php
@@ -104,7 +104,9 @@ class ComposerTool extends Tool {
    */
   protected function initialize() {
     $factory = new Factory();
-    $rootPath = $this->jorge->getPath();
+    if (($rootPath = $this->jorge->getPath()) === NULL) {
+      return;
+    }
     $composerJson = $rootPath . '/composer.json';
     if (!is_file($composerJson)) {
       return;

--- a/src/Tool/GitTool.php
+++ b/src/Tool/GitTool.php
@@ -84,7 +84,10 @@ class GitTool extends Tool {
    */
   protected function initialize() {
     if (!empty($this->getExecutable())) {
-      chdir($this->jorge->getPath());
+      if (($rootPath = $this->jorge->getPath()) === NULL) {
+        return;
+      }
+      chdir($rootPath);
       $exec = $this->exec('status 2>&1');
       if ($exec['status'] == 0) {
         $this->enable();

--- a/tests/JorgeDefaultTest.php
+++ b/tests/JorgeDefaultTest.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types = 1);
 
+namespace MountHolyoke\JorgeTests;
+
 use MountHolyoke\Jorge\Jorge;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\ConsoleOutput;

--- a/tests/JorgeDefaultTest.php
+++ b/tests/JorgeDefaultTest.php
@@ -48,4 +48,15 @@ final class JorgeDefaultTest extends TestCase {
     $this->assertGreaterThan(count($defaultCommands), count($this->jorge->all()));
     $this->assertGreaterThan(count($defaultTools), count($this->jorge->allTools()));
   }
+
+  /**
+   * Make sure Jorge runs without errors.
+   */
+  public function testRun(): void {
+    $this->jorge->configure();
+    $this->jorge->setAutoExit(FALSE);
+    $output = $this->jorge->getOutput();
+    $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+    $this->assertSame(0, $this->jorge->run());
+  }
 }

--- a/tests/JorgeDefaultTest.php
+++ b/tests/JorgeDefaultTest.php
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class JorgePreTest extends TestCase {
+final class JorgeDefaultTest extends TestCase {
   protected $jorge;
 
   protected function setUp() {
@@ -31,7 +31,7 @@ final class JorgePreTest extends TestCase {
   /**
    * Test default configuration.
    */
-  public function testDefaultConfigure(): void {
+  public function testConfigure(): void {
     $defaultCommands = $this->jorge->all();
     $defaultTools = $this->jorge->allTools();
 
@@ -39,7 +39,6 @@ final class JorgePreTest extends TestCase {
 
     $this->assertSame('Jorge', $this->jorge->getName());
     $this->assertRegExp('/\d\.\d\.\d/', $this->jorge->getVersion());
-
     $this->assertSame(__DIR__, $this->jorge->getPath('tests', TRUE));
     $this->assertSame('jorge', $this->jorge->getConfig('appType'));
 
@@ -47,15 +46,4 @@ final class JorgePreTest extends TestCase {
     $this->assertGreaterThan(count($defaultCommands), count($this->jorge->all()));
     $this->assertGreaterThan(count($defaultTools), count($this->jorge->allTools()));
   }
-
-
-  // TODO: test pathfinding and loading config given various mocks/fixtures:
-  // config['includeconfig']
-  // static findRootPath()
-  // getConfig()
-  // getPath()
-  // loadConfigFile()
-  // static sanitizePath()
-
-
 }

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -1,6 +1,8 @@
 <?php
 declare(strict_types = 1);
 
+namespace MountHolyoke\JorgeTests;
+
 use MountHolyoke\Jorge\Jorge;
 use PHPUnit\Framework\TestCase;
 use Spatie\TemporaryDirectory\TemporaryDirectory;

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -22,12 +22,13 @@ final class JorgePreTest extends TestCase {
   }
 
   /**
-   * Sets up a minimal with no .jorge subdirectory
+   * Tries configure() when there is no .jorge subdirectory.
    */
   public function testNoDotJorge(): void {
     $root = $this->tempDir->path();
     chdir($root);
     $this->jorge->configure();
+    $this->assertNull($this->jorge->getPath());
   }
 
 

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -36,38 +36,6 @@ final class JorgePreTest extends TestCase {
   }
 
   /**
-   * Finds the project root from a random subdirectory.
-   */
-  public function testFindRootPath(): void {
-    $root = realpath($this->tempDir->path());
-    $depth = 2 + random_int(0, 4);
-    $path = $root;
-    for ($i = 0; $i < $depth; $i++) {
-      $path .= DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
-      mkdir($path);
-    }
-    chdir($path);
-    $this->jorge->configure();
-    $this->assertSame($root, $this->jorge->getPath());
-  }
-
-  /**
-   * Finds the project root from a random subdirectory.
-   */
-  public function testFindRootPath(): void {
-    $root = realpath($this->tempDir->path());
-    $depth = 2 + random_int(0, 4);
-    $path = $root;
-    for ($i = 0; $i < $depth; $i++) {
-      $path .= DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
-      mkdir($path);
-    }
-    chdir($path);
-    $this->jorge->configure();
-    $this->assertSame($root, $this->jorge->getPath());
-  }
-
-  /**
    * Tries configure() when .jorge is empty.
    */
   public function testEmptyDotJorge(): void {
@@ -75,6 +43,22 @@ final class JorgePreTest extends TestCase {
     $this->jorge->configure();
     $this->assertSame($root, $this->jorge->getPath());
     $this->assertSame([], $this->jorge->getConfig());
+  }
+
+  /**
+   * Finds the project root from a random subdirectory.
+   */
+  public function testFindRootPath(): void {
+    $root = realpath($this->tempDir->path());
+    $depth = 2 + random_int(0, 4);
+    $path = $root;
+    for ($i = 0; $i < $depth; $i++) {
+      $path .= DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
+      mkdir($path);
+    }
+    chdir($path);
+    $this->jorge->configure();
+    $this->assertSame($root, $this->jorge->getPath());
   }
 
   /**
@@ -87,7 +71,7 @@ final class JorgePreTest extends TestCase {
     mkdir($subdir);
     $this->jorge->configure();
     $this->assertSame($subdir, $this->jorge->getPath($randir));
-    $this->assertSame($root, $this->jorge->getPath($randir . 'x'));
+    $this->assertNull($this->jorge->getPath($randir . 'x'));
     $this->expectException(\DomainException::class);
     $this->jorge->getPath($randir . 'x', TRUE);
   }

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -31,6 +31,24 @@ final class JorgePreTest extends TestCase {
     rmdir($root . DIRECTORY_SEPARATOR . '.jorge');
     $this->jorge->configure();
     $this->assertNull($this->jorge->getPath());
+    $this->expectException(\DomainException::class);
+    $this->jorge->getPath('', TRUE);
+  }
+
+  /**
+   * Finds the project root from a random subdirectory.
+   */
+  public function testFindRootPath(): void {
+    $root = realpath($this->tempDir->path());
+    $depth = 2 + random_int(0, 4);
+    $path = $root;
+    for ($i = 0; $i < $depth; $i++) {
+      $path .= DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
+      mkdir($path);
+    }
+    chdir($path);
+    $this->jorge->configure();
+    $this->assertSame($root, $this->jorge->getPath());
   }
 
   /**
@@ -70,6 +88,8 @@ final class JorgePreTest extends TestCase {
     $this->jorge->configure();
     $this->assertSame($subdir, $this->jorge->getPath($randir));
     $this->assertSame($root, $this->jorge->getPath($randir . 'x'));
+    $this->expectException(\DomainException::class);
+    $this->jorge->getPath($randir . 'x', TRUE);
   }
 
   /**
@@ -90,7 +110,6 @@ final class JorgePreTest extends TestCase {
 
   // TODO: test pathfinding and loading config given various mocks/fixtures:
   // config['includeconfig']
-  // getPath() Exceptions
   // loadConfigFile()
   // static sanitizePath()
 

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -97,6 +97,17 @@ final class JorgePreTest extends TestCase {
   }
 
   /**
+   * Generate empty config file.
+   */
+  public function testEmptyConfig(): void {
+    $root = realpath($this->tempDir->path());
+    $configFile = implode(DIRECTORY_SEPARATOR, [$root, '.jorge', 'config.yml']);
+    touch($configFile);
+    $this->jorge->configure();
+    $this->assertSame([], $this->jorge->getConfig());
+  }
+
+  /**
    * Generate random config file.
    */
   public function testGetConfig(): void {

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -117,8 +117,8 @@ final class JorgePreTest extends TestCase {
     $configValue = bin2hex(random_bytes(4));
     file_put_contents($configFile, "{$configKey}: {$configValue}\n");
     $this->jorge->configure();
-    $this->assertSame($configValue, $this->jorge->getConfig($configKey));
-    $this->assertSame($configValue, $this->jorge->getConfig($configKey, 'X'));
+    $this->assertSame((string)$configValue, $this->jorge->getConfig($configKey));
+    $this->assertSame((string)$configValue, $this->jorge->getConfig($configKey, 'X'));
     $this->assertNull($this->jorge->getConfig($configKey . 'x'));
     $this->assertSame('X', $this->jorge->getConfig($configKey . 'x', 'X'));
   }
@@ -136,9 +136,9 @@ final class JorgePreTest extends TestCase {
     $mainInnerVal2 = bin2hex(random_bytes(4));
     $newConfigName = bin2hex(random_bytes(4)) . '.yml';
     $mainFileYaml = Yaml::dump([
-      $mainOuterKey => [
-        $mainInnerKey1 => $mainInnerVal1,
-        $mainInnerKey2 => $mainInnerVal2,
+      (string)$mainOuterKey => [
+        (string)$mainInnerKey1 => (string)$mainInnerVal1,
+        (string)$mainInnerKey2 => (string)$mainInnerVal2,
       ],
       'include_config' => $newConfigName,
     ]);
@@ -153,11 +153,11 @@ final class JorgePreTest extends TestCase {
     $newOuterKey = bin2hex(random_bytes(4));     # supplement outer
     $newOuterVal = bin2hex(random_bytes(4));
     $newFileYaml = Yaml::dump([
-      $mainOuterKey => [
-        $mainInnerKey2 => $newInnerVal2,
-        $newInnerKey3  => $newInnerVal3,
+      (string)$mainOuterKey => [
+        (string)$mainInnerKey2 => (string)$newInnerVal2,
+        (string)$newInnerKey3  => (string)$newInnerVal3,
       ],
-      $newOuterKey => $newOuterVal,
+      (string)$newOuterKey => (string)$newOuterVal,
     ]);
     $newConfigFile = implode(DIRECTORY_SEPARATOR, [$root, '.jorge', $newConfigName]);
     file_put_contents($newConfigFile, $newFileYaml);
@@ -165,9 +165,9 @@ final class JorgePreTest extends TestCase {
     $this->jorge->configure();
 
     $combined = [
-      $mainInnerKey1 => $mainInnerVal1,
-      $mainInnerKey2 => [$mainInnerVal2, $newInnerVal2],
-      $newInnerKey3  => $newInnerVal3,
+      (string)$mainInnerKey1 => (string)$mainInnerVal1,
+      (string)$mainInnerKey2 => [(string)$mainInnerVal2, (string)$newInnerVal2],
+      (string)$newInnerKey3  => (string)$newInnerVal3,
     ];
     $this->assertSame($combined, $this->jorge->getConfig($mainOuterKey));
     $this->assertSame($newOuterVal, $this->jorge->getConfig($newOuterKey));

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -116,12 +116,12 @@ final class JorgePreTest extends TestCase {
     $configFile = implode(DIRECTORY_SEPARATOR, [$root, '.jorge', 'config.yml']);
     $configKey = bin2hex(random_bytes(4));
     $configValue = bin2hex(random_bytes(4));
-    file_put_contents($configFile, "${configKey}: $configValue\n");
+    file_put_contents($configFile, "x$configKey : x$configValue\n");
     $this->jorge->configure();
-    $this->assertSame("$configValue", $this->jorge->getConfig("$configKey"));
-    $this->assertSame("$configValue", $this->jorge->getConfig("$configKey", 'X'));
-    $this->assertNull($this->jorge->getConfig("${configKey}x"));
-    $this->assertSame('X', $this->jorge->getConfig("${configKey}x", 'X'));
+    $this->assertSame("x$configValue", $this->jorge->getConfig("x$configKey"));
+    $this->assertSame("x$configValue", $this->jorge->getConfig("x$configKey", 'X'));
+    $this->assertNull($this->jorge->getConfig("xx$configKey"));
+    $this->assertSame('X', $this->jorge->getConfig("xx$configKey", 'X'));
   }
 
   /**
@@ -137,9 +137,9 @@ final class JorgePreTest extends TestCase {
     $mainInnerVal2 = bin2hex(random_bytes(4));
     $newConfigName = bin2hex(random_bytes(4)) . '.yml';
     $mainFileYaml = Yaml::dump([
-      "$mainOuterKey" => [
-        "$mainInnerKey1" => "$mainInnerVal1",
-        "$mainInnerKey2" => "$mainInnerVal2",
+      "x$mainOuterKey" => [
+        "x$mainInnerKey1" => "x$mainInnerVal1",
+        "x$mainInnerKey2" => "x$mainInnerVal2",
       ],
       'include_config' => $newConfigName,
     ]);
@@ -154,11 +154,11 @@ final class JorgePreTest extends TestCase {
     $newOuterKey = bin2hex(random_bytes(4));     # supplement outer
     $newOuterVal = bin2hex(random_bytes(4));
     $newFileYaml = Yaml::dump([
-      "$mainOuterKey" => [
-        "$mainInnerKey2" => "$newInnerVal2",
-        "$newInnerKey3"  => "$newInnerVal3",
+      "x$mainOuterKey" => [
+        "x$mainInnerKey2" => "x$newInnerVal2",
+        "x$newInnerKey3"  => "x$newInnerVal3",
       ],
-      "$newOuterKey" => "$newOuterVal",
+      "x$newOuterKey" => "x$newOuterVal",
     ]);
     $newConfigFile = implode(DIRECTORY_SEPARATOR, [$root, '.jorge', $newConfigName]);
     file_put_contents($newConfigFile, $newFileYaml);
@@ -166,11 +166,11 @@ final class JorgePreTest extends TestCase {
     $this->jorge->configure();
 
     $combined = [
-      "$mainInnerKey1" => "$mainInnerVal1",
-      "$mainInnerKey2" => ["$mainInnerVal2", "$newInnerVal2"],
-      "$newInnerKey3"  => "$newInnerVal3",
+      "x$mainInnerKey1" => "x$mainInnerVal1",
+      "x$mainInnerKey2" => ["x$mainInnerVal2", "x$newInnerVal2"],
+      "x$newInnerKey3"  => "x$newInnerVal3",
     ];
-    $this->assertSame($combined, $this->jorge->getConfig("$mainOuterKey"));
-    $this->assertSame("$newOuterVal", $this->jorge->getConfig("$newOuterKey"));
+    $this->assertSame($combined, $this->jorge->getConfig("x$mainOuterKey"));
+    $this->assertSame("x$newOuterVal", $this->jorge->getConfig("x$newOuterKey"));
   }
 }

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types = 1);
+
+use MountHolyoke\Jorge\Jorge;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class JorgePreTest extends TestCase {
+  protected $jorge;
+
+  protected function setUp() {
+    $this->jorge = new Jorge();
+  }
+
+  /**
+   * Test basic instantiation.
+   *
+   * Jorge’s __construct() creates and configures $input and $output before
+   * a typical Symfony application because we need them for setup.
+   */
+  public function testConstruct(): void {
+    $this->assertInstanceOf(Jorge::class, $this->jorge);
+    $output = $this->jorge->getOutput();
+    $this->assertInstanceOf(ConsoleOutput::class, $output);
+    $this->assertTrue($output->isDecorated());
+    $this->assertSame(OutputInterface::VERBOSITY_NORMAL, $output->getVerbosity());
+    $this->assertSame(0, $_ENV['SHELL_VERBOSITY']);
+  }
+
+  /**
+   * Test default configuration.
+   */
+  public function testDefaultConfigure(): void {
+    $defaultCommands = $this->jorge->all();
+    $defaultTools = $this->jorge->allTools();
+
+    $this->jorge->configure();
+
+    $this->assertSame('Jorge', $this->jorge->getName());
+    $this->assertRegExp('/\d\.\d\.\d/', $this->jorge->getVersion());
+
+    $this->assertSame(__DIR__, $this->jorge->getPath('tests', TRUE));
+    $this->assertSame('jorge', $this->jorge->getConfig('appType'));
+
+    # Commands and Tools are added.
+    $this->assertGreaterThan(count($defaultCommands), count($this->jorge->all()));
+    $this->assertGreaterThan(count($defaultTools), count($this->jorge->allTools()));
+  }
+
+
+  // TODO: test pathfinding and loading config given various mocks/fixtures:
+  // config['includeconfig']
+  // static findRootPath()
+  // getConfig()
+  // getPath()
+  // loadConfigFile()
+  // static sanitizePath()
+
+
+}

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types = 1);
+
+use MountHolyoke\Jorge\Jorge;
+use PHPUnit\Framework\TestCase;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class JorgePreTest extends TestCase {
+  protected $jorge;
+  protected $tempDir;
+
+  protected function setUp() {
+    $this->jorge = new Jorge();
+    $output = $this->jorge->getOutput();
+    $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+    $this->tempDir = (new TemporaryDirectory())->create();
+  }
+
+  protected function tearDown() {
+    $this->tempDir->delete();
+  }
+
+  /**
+   * Sets up a minimal with no .jorge subdirectory
+   */
+  public function testNoDotJorge(): void {
+    $root = $this->tempDir->path();
+    chdir($root);
+    $this->jorge->configure();
+  }
+
+
+  // TODO: test pathfinding and loading config given various mocks/fixtures:
+  // config['includeconfig']
+  // static findRootPath()
+  // getConfig()
+  // getPath()
+  // loadConfigFile()
+  // static sanitizePath()
+
+
+}

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -77,6 +77,23 @@ final class JorgePreTest extends TestCase {
   }
 
   /**
+   * Generate random subdirectory.
+   */
+  public function testSanitizePath() {
+    $root = realpath($this->tempDir->path());
+    $randir = bin2hex(random_bytes(4));
+    $subdir = $root . DIRECTORY_SEPARATOR . $randir;
+    mkdir($subdir);
+    $this->jorge->configure();
+    $prefixes = ['/', '../', './..//./ /'];
+    foreach ($prefixes as $prefix) {
+      $this->assertSame($root, $this->jorge->getPath($prefix));
+      $this->assertSame($subdir, $this->jorge->getPath($prefix . $randir));
+      $this->assertNull($this->jorge->getPath($prefix . $randir . 'x'));
+    }
+  }
+
+  /**
    * Generate random config file.
    */
   public function testGetConfig(): void {
@@ -95,7 +112,6 @@ final class JorgePreTest extends TestCase {
   // TODO: test pathfinding and loading config given various mocks/fixtures:
   // config['includeconfig']
   // loadConfigFile()
-  // static sanitizePath()
 
 
 }

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -15,6 +15,8 @@ final class JorgePreTest extends TestCase {
     $output = $this->jorge->getOutput();
     $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
     $this->tempDir = (new TemporaryDirectory())->create();
+    mkdir($this->tempDir->path() . DIRECTORY_SEPARATOR . '.jorge');
+    chdir($this->tempDir->path());
   }
 
   protected function tearDown() {
@@ -26,9 +28,25 @@ final class JorgePreTest extends TestCase {
    */
   public function testNoDotJorge(): void {
     $root = realpath($this->tempDir->path());
-    chdir($root);
+    rmdir($root . DIRECTORY_SEPARATOR . '.jorge');
     $this->jorge->configure();
     $this->assertNull($this->jorge->getPath());
+  }
+
+  /**
+   * Finds the project root from a random subdirectory.
+   */
+  public function testFindRootPath(): void {
+    $root = realpath($this->tempDir->path());
+    $depth = 2 + random_int(0, 4);
+    $path = $root;
+    for ($i = 0; $i < $depth; $i++) {
+      $path .= DIRECTORY_SEPARATOR . bin2hex(random_bytes(4));
+      mkdir($path);
+    }
+    chdir($path);
+    $this->jorge->configure();
+    $this->assertSame($root, $this->jorge->getPath());
   }
 
   /**
@@ -36,19 +54,43 @@ final class JorgePreTest extends TestCase {
    */
   public function testEmptyDotJorge(): void {
     $root = realpath($this->tempDir->path());
-    mkdir($root . DIRECTORY_SEPARATOR . '.jorge');
-    chdir($root);
     $this->jorge->configure();
     $this->assertSame($root, $this->jorge->getPath());
     $this->assertSame([], $this->jorge->getConfig());
   }
 
+  /**
+   * Generate random subdirectory.
+   */
+  public function testGetPath(): void {
+    $root = realpath($this->tempDir->path());
+    $randir = bin2hex(random_bytes(4));
+    $subdir = $root . DIRECTORY_SEPARATOR . $randir;
+    mkdir($subdir);
+    $this->jorge->configure();
+    $this->assertSame($subdir, $this->jorge->getPath($randir));
+    $this->assertSame($root, $this->jorge->getPath($randir . 'x'));
+  }
+
+  /**
+   * Generate random config file.
+   */
+  public function testGetConfig(): void {
+    $root = realpath($this->tempDir->path());
+    $configFile = implode(DIRECTORY_SEPARATOR, [$root, '.jorge', 'config.yml']);
+    $configKey = bin2hex(random_bytes(4));
+    $configValue = bin2hex(random_bytes(4));
+    file_put_contents($configFile, "{$configKey}: {$configValue}\n");
+    $this->jorge->configure();
+    $this->assertSame($configValue, $this->jorge->getConfig($configKey));
+    $this->assertSame($configValue, $this->jorge->getConfig($configKey, 'X'));
+    $this->assertNull($this->jorge->getConfig($configKey . 'x'));
+    $this->assertSame('X', $this->jorge->getConfig($configKey . 'x', 'X'));
+  }
 
   // TODO: test pathfinding and loading config given various mocks/fixtures:
   // config['includeconfig']
-  // static findRootPath()
-  // getConfig()
-  // getPath()
+  // getPath() Exceptions
   // loadConfigFile()
   // static sanitizePath()
 

--- a/tests/JorgePreTest.php
+++ b/tests/JorgePreTest.php
@@ -25,10 +25,22 @@ final class JorgePreTest extends TestCase {
    * Tries configure() when there is no .jorge subdirectory.
    */
   public function testNoDotJorge(): void {
-    $root = $this->tempDir->path();
+    $root = realpath($this->tempDir->path());
     chdir($root);
     $this->jorge->configure();
     $this->assertNull($this->jorge->getPath());
+  }
+
+  /**
+   * Tries configure() when .jorge is empty.
+   */
+  public function testEmptyDotJorge(): void {
+    $root = realpath($this->tempDir->path());
+    mkdir($root . DIRECTORY_SEPARATOR . '.jorge');
+    chdir($root);
+    $this->jorge->configure();
+    $this->assertSame($root, $this->jorge->getPath());
+    $this->assertSame([], $this->jorge->getConfig());
   }
 
 

--- a/tests/JorgeTest.php
+++ b/tests/JorgeTest.php
@@ -5,9 +5,19 @@ use MountHolyoke\Jorge\Jorge;
 use PHPUnit\Framework\TestCase;
 
 final class JorgeTest extends TestCase {
-  public function testJorgeInstantiation(): Jorge {
-    $jorge = new Jorge();
-    $this->assertInstanceOf(Jorge::class, $jorge);
-    return $jorge;
+  protected $jorge;
+
+  /**
+   * @todo Mocked IO
+   */
+  protected function setUp() {
+    $this->jorge = new Jorge();
+    $this->jorge->configure();
   }
+
+  // TODO test log
+
+  // TODO test post-config functionality
+  // getTool()
+  // run()
 }

--- a/tests/JorgeTest.php
+++ b/tests/JorgeTest.php
@@ -1,21 +1,41 @@
 <?php
 declare(strict_types = 1);
 
+namespace MountHolyoke\JorgeTests;
+
+use MountHolyoke\JorgeTests\MockJorge;
 use MountHolyoke\Jorge\Jorge;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 final class JorgeTest extends TestCase {
   protected $jorge;
 
   /**
-   * @todo Mocked IO
+   * Creates a Jorge object with its log() methed replaced so we can test output.
    */
-  protected function setUp() {
-    $this->jorge = new Jorge();
-    $this->jorge->configure();
-  }
+   protected function setUp(): void {
+     $this->jorge = new MockJorge();
+     // $output = $this->jorge->getOutput();
+     // $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
+     // $this->tempDir = (new TemporaryDirectory())->create();
+     // mkdir($this->tempDir->path() . DIRECTORY_SEPARATOR . '.jorge');
+     // chdir($this->tempDir->path());
+     $this->jorge->configure();
+   }
 
-  // TODO test log
+   // protected function tearDown(): void {
+   //   $this->tempDir->delete();
+   // }
+
+   public function testMockJorge() {
+     $this->assertSame('Jorge', $this->jorge->getName());
+     $this->expectOutputString("warning: using MockJorge\n");
+     $this->jorge->log(LogLevel::WARNING, 'using MockJorge');
+   }
+
+  // TODO test log levels
 
   // TODO test post-config functionality
   // getTool()

--- a/tests/JorgeTest.php
+++ b/tests/JorgeTest.php
@@ -3,12 +3,13 @@ declare(strict_types = 1);
 
 namespace MountHolyoke\JorgeTests;
 
+use MountHolyoke\JorgeTests\MockConsoleOutput;
 use MountHolyoke\JorgeTests\MockJorge;
-use MountHolyoke\Jorge\Jorge;
+use MountHolyoke\Jorge\Tool\Tool;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
-use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
 
 final class JorgeTest extends TestCase {
   protected $jorge;
@@ -22,22 +23,55 @@ final class JorgeTest extends TestCase {
     $root = $this->tempDir->path();
     mkdir($root . DIRECTORY_SEPARATOR . '.jorge');
     chdir($root);
+    touch('.jorge' . DIRECTORY_SEPARATOR . 'config.yml');
     $this->jorge = new MockJorge($root);
-    // $output = $this->jorge->getOutput();
-    // $output->setVerbosity(OutputInterface::VERBOSITY_QUIET);
     $this->jorge->configure();
   }
 
   protected function tearDown(): void {
+    $this->jorge = NULL;
     $this->tempDir->delete();
   }
 
   /**
-   * Verify the MockJorge is working as expected
+   * Verify the MockJorge is working as expected: that it starts the same as
+   * a typical Jorge, but with output functions replaced.
    */
   public function testMockJorge() {
-    $this->assertSame('Jorge', $this->jorge->getName());
+    # Startup messages (all verbosities):
+    $startup = [
+      [LogLevel::NOTICE, 'Project root: {%root}'],
+      [LogLevel::DEBUG,  '{composer} Executable is "{%executable}"'],
+      [LogLevel::DEBUG,  '{git} Executable is "{%executable}"'],
+      [LogLevel::NOTICE, '{git} $ {%command}'],
+      [LogLevel::DEBUG,  '{lando} Executable is "{%executable}"'],
+      ['NULL',           'Can’t read config file {%filename}'],
+    ];
+    $this->assertSame(count($startup), count($this->jorge->messages));
+    foreach ($startup as $expected) {
+      $actual = array_shift($this->jorge->messages);
+      # Paths may be different on different computers
+      array_pop($actual);
+      $this->assertSame($expected, $actual);
+    }
+    $this->assertSame(0, count($this->jorge->messages));
 
+    # From __construct():
+    $this->assertInstanceOf(MockJorge::class, $this->jorge);
+    $output = $this->jorge->getOutput();
+    $this->assertInstanceOf(MockConsoleOutput::class, $output);
+    $this->assertTrue($output->isDecorated());
+    $this->assertSame(OutputInterface::VERBOSITY_NORMAL, $output->getVerbosity());
+    $this->assertSame(0, $_ENV['SHELL_VERBOSITY']);
+
+    # From configure():
+    $this->assertSame('Jorge', $this->jorge->getName());
+    $this->assertRegExp('/\d\.\d\.\d/', $this->jorge->getVersion());
+    $this->assertSame(realpath($this->tempDir->path()), $this->jorge->getPath());
+    $this->assertSame([], $this->jorge->getConfig());
+    // $this->assertSame('jorge', $this->jorge->getConfig('appType'));
+
+    # Verify that MockJorge’s log() works as expected:
     $logLevels = [
       LogLevel::EMERGENCY,
       LogLevel::ALERT,
@@ -50,18 +84,38 @@ final class JorgeTest extends TestCase {
     ];
     foreach ($logLevels as $logLevel) {
       $logString = bin2hex(random_bytes(4));
-      $logExpect = [$logLevel, $logString, []];
+      $logExpect = [$logLevel, (string)$logString, []];
       $this->jorge->log($logLevel, $logString);
       $this->assertSame($logExpect, end($this->jorge->messages));
     }
 
+    # Verify that writeln works as expected:
     $wlnString = bin2hex(random_bytes(4));
-    $wlnExpect = ['writeln', $wlnString];
+    $wlnExpect = ['writeln', (string)$wlnString];
     $this->jorge->getOutput()->writeln($wlnString);
     $this->assertSame($wlnExpect, end($this->jorge->messages));
   }
 
+  public function testGetTool(): void {
+    # Find a name we don’t have and verify that getTool() responds correctly.
+    do {
+      $toolName = bin2hex(random_bytes(4));
+    } while (array_key_exists($toolName, $this->jorge->allTools()));
+    $this->assertNull($this->jorge->getTool($toolName));
+    $expectLog = [LogLevel::WARNING, 'Can’t get tool "{%tool}"', ['%tool' => $toolName]];
+    $this->assertSame($expectLog, end($this->jorge->messages));
+
+    # Add a tool with that name and verify that getTool() responds correctly.
+    $toolInstance = new Tool($toolName);
+    $this->jorge->addTool($toolInstance, 'echo');
+    $this->assertArrayHasKey($toolName, $this->jorge->allTools());
+    $this->assertSame($toolInstance, $this->jorge->getTool($toolName));
+
+    # This should echo the tool name without checking enablement.
+    $toolInstance->runThis($toolName);
+    $this->assertSame(['writeln', $toolName], end($this->jorge->messages));
+  }
+
   // TODO test post-config functionality
-  // getTool()
   // run()
 }

--- a/tests/JorgeTest.php
+++ b/tests/JorgeTest.php
@@ -9,6 +9,7 @@ use MountHolyoke\Jorge\Tool\Tool;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
+use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class JorgeTest extends TestCase {
@@ -96,7 +97,7 @@ final class JorgeTest extends TestCase {
     $this->assertSame($wlnExpect, end($this->jorge->messages));
   }
 
-  public function testGetTool(): void {
+  public function testAddToolGetTool(): void {
     # Find a name we don’t have and verify that getTool() responds correctly.
     do {
       $toolName = bin2hex(random_bytes(4));
@@ -110,6 +111,10 @@ final class JorgeTest extends TestCase {
     $this->jorge->addTool($toolInstance, 'echo');
     $this->assertArrayHasKey($toolName, $this->jorge->allTools());
     $this->assertSame($toolInstance, $this->jorge->getTool($toolName));
+
+    # Add another tool with that name and verify that we get an exception.
+    $this->expectException(LogicException::class);
+    $this->jorge->addTool(new Tool($toolName), 'ls');
 
     # This should echo the tool name without checking enablement.
     $toolInstance->runThis($toolName);

--- a/tests/JorgeTest.php
+++ b/tests/JorgeTest.php
@@ -84,15 +84,15 @@ final class JorgeTest extends TestCase {
     ];
     foreach ($logLevels as $logLevel) {
       $logString = bin2hex(random_bytes(4));
-      $logExpect = [$logLevel, (string)$logString, []];
-      $this->jorge->log($logLevel, $logString);
+      $logExpect = [$logLevel, "$logString", []];
+      $this->jorge->log($logLevel, "$logString");
       $this->assertSame($logExpect, end($this->jorge->messages));
     }
 
     # Verify that writeln works as expected:
     $wlnString = bin2hex(random_bytes(4));
-    $wlnExpect = ['writeln', (string)$wlnString];
-    $this->jorge->getOutput()->writeln($wlnString);
+    $wlnExpect = ['writeln', "$wlnString"];
+    $this->jorge->getOutput()->writeln("$wlnString");
     $this->assertSame($wlnExpect, end($this->jorge->messages));
   }
 
@@ -116,6 +116,20 @@ final class JorgeTest extends TestCase {
     $this->assertSame(['writeln', $toolName], end($this->jorge->messages));
   }
 
-  // TODO test post-config functionality
-  // run()
+  /**
+   * @todo How do we actually verify this is the normal start?
+   */
+  public function testRun(): void {
+    $this->jorge->messages = [];
+    $this->jorge->run();
+
+    # Number of lines of output is predictable.
+    $numLines = 22 + (2 * count($this->jorge->all()));
+    $this->assertSame($numLines, count($this->jorge->messages));
+
+    # None of the lines should indicate an error.
+    foreach ($this->jorge->messages as $message) {
+      $this->assertNotRegExp('/<(warning|error|critical|alert|emergency)>/', $message[1]);
+    }
+  }
 }

--- a/tests/JorgeTest.php
+++ b/tests/JorgeTest.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types = 1);
+
+use MountHolyoke\Jorge\Jorge;
+use PHPUnit\Framework\TestCase;
+
+final class JorgeTest extends TestCase {
+  public function testJorgeInstantiation(): Jorge {
+    $jorge = new Jorge();
+    $this->assertInstanceOf(Jorge::class, $jorge);
+    return $jorge;
+  }
+}

--- a/tests/MockConsoleOutput.php
+++ b/tests/MockConsoleOutput.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types = 1);
+
+namespace MountHolyoke\JorgeTests;
+
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+/**
+ * This class exists to trap the normal output instead of printing it.
+ *
+ * As a first pass, we replace the output streams php://stdout and php://stderr
+ * with php://output, which can be captured by PHPUnit. Alternative apporaches
+ * (which may be necessary for advanced testing) include replacing or altering
+ * those with php://memory or php://filter, and creating a new formatter.
+ */
+class MockConsoleOutput extends ConsoleOutput {
+  private $stderr;
+  private $jorge;
+
+  /**
+   * Capture a link back to Jorge for its messages[].
+   */
+  public function __construct($jorge, $verbosity) {
+    parent::__construct($verbosity);
+    $this->jorge = $jorge;
+  }
+
+  /**
+   * N/A in test environment.
+   */
+  private function isRunningOS400() {
+    return FALSE;
+  }
+
+  /**
+   * php://output can be captured by PHPUnit, php://stdout can’t.
+   *
+   * This is only used for output that doesn’t go through logger or write().
+   *
+   * @return resource
+   */
+  private function openOutputStream() {
+    return fopen('php://output', 'w');
+  }
+
+  /**
+   * php://output can be captured by PHPUnit, php://stderr can’t.
+   *
+   * This is only used for output that doesn’t go through logger or write().
+   *
+   * @return resource
+   */
+  private function openErrorStream() {
+    return fopen('php://output', 'w');
+  }
+
+  /**
+   * When possible, save stuff directly to a place we can get it.
+   *
+   * {@inheritDoc}
+   */
+  public function write($messages, $newline = FALSE, $options = ConsoleOutput::OUTPUT_NORMAL) {
+    $messages = (array) $messages;
+    foreach ($messages as $message) {
+      $this->jorge->messages[] = ['write', $message];
+    }
+  }
+
+  /**
+  * When possible, save stuff directly to a place we can get it.
+  *
+   * {@inheritDoc}
+   */
+  public function writeln($messages, $options = ConsoleOutput::OUTPUT_NORMAL) {
+    $messages = (array) $messages;
+    foreach ($messages as $message) {
+      $this->jorge->messages[] = ['writeln', $message];
+    }
+  }
+}

--- a/tests/MockJorge.php
+++ b/tests/MockJorge.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types = 1);
+
+namespace MountHolyoke\JorgeTests;
+
+use MountHolyoke\Jorge\Jorge;
+
+class MockJorge {
+  private $jorge;
+  public function __construct() {
+    $this->jorge = new Jorge();
+    $this->jorge->configure();
+  }
+
+  public function __call($name, $args) {
+    return $this->jorge->$name($args);
+  }
+
+  public function log($level, $message, array $context=[]) {
+    print "{$level}: {$message}\n";
+  }
+}

--- a/tests/MockJorge.php
+++ b/tests/MockJorge.php
@@ -4,19 +4,75 @@ declare(strict_types = 1);
 namespace MountHolyoke\JorgeTests;
 
 use MountHolyoke\Jorge\Jorge;
+use MountHolyoke\JorgeTests\MockConsoleOutput;
+use Symfony\Component\Console\Logger\ConsoleLogger;
 
-class MockJorge {
-  private $jorge;
-  public function __construct() {
-    $this->jorge = new Jorge();
-    $this->jorge->configure();
+/**
+ * This is a wrapper class so we can capture the output, since we don’t
+ * otherwise have a mechanism to substitute a more traditional mock.
+ */
+class MockJorge extends Jorge {
+  /** {@inheritDoc} */
+  private $config = [];
+
+  /** {@inheritDoc} */
+  private $input;
+
+  /** {@inheritDoc} */
+  private $logger;
+
+  /** {@inheritDoc} */
+  private $output;
+
+  /** {@inheritDoc} */
+  private $rootPath;
+
+  /** {@inheritDoc} */
+  private $tools;
+
+  /** @var array $messages Things that would have gone to console output */
+  public $messages = [];
+
+  /**
+   * Instantiates the object and replaces its output interfaces.
+   *
+   * @param string $rootPath The temporary directory serving as root, because
+   *                         we have to stub findRootPath() also.
+   */
+  public function __construct($rootPath) {
+    parent::__construct();
+    $this->rootPath = $rootPath;
+    $this->output = new MockConsoleOutput($this, parent::getOutput()->getVerbosity());
+    $this->logger = new ConsoleLogger($this->output);
   }
 
-  public function __call($name, $args) {
-    return $this->jorge->$name($args);
+  /**
+   * Stub because we can’t inherit a private function.
+   */
+  private static function findRootPath() {
+    return $this->rootPath;
   }
 
-  public function log($level, $message, array $context=[]) {
-    print "{$level}: {$message}\n";
+  /**
+   * {@inheritDoc}
+   */
+  public function getOutput() {
+    return $this->output;
+  }
+
+  /**
+   * Replaces log() with a method that returns instead of printing.
+   *
+   * Note that this also ignores verbosity: all messages will be included.
+   *
+   * @param string|null $level   What log level to use, or NULL to ignore
+   * @param string      $message May need $context interpolation
+   * @param array       $context Variable substitutions for $message
+   * @return array The original parameters
+   * @see \Symfony\Component\Console\Logger\ConsoleLogger
+   */
+  public function log($level, $message, array $context = []) {
+    $levelString = ($level === NULL) ? 'NULL' : $level;
+    $this->messages[] = [$levelString, $message, $context];
   }
 }

--- a/tests/MockJorge.php
+++ b/tests/MockJorge.php
@@ -83,6 +83,6 @@ class MockJorge extends Jorge {
    * {@inheritDoc}
    */
   public function run(InputInterface $input = NULL, OutputInterface $output = NULL) {
-    parent::run(NULL, $this->getOutput());
+    return parent::run(NULL, $this->getOutput());
   }
 }

--- a/tests/MockJorge.php
+++ b/tests/MockJorge.php
@@ -5,7 +5,9 @@ namespace MountHolyoke\JorgeTests;
 
 use MountHolyoke\Jorge\Jorge;
 use MountHolyoke\JorgeTests\MockConsoleOutput;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Logger\ConsoleLogger;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * This is a wrapper class so we can capture the output, since we don’t
@@ -44,6 +46,7 @@ class MockJorge extends Jorge {
     $this->rootPath = $rootPath;
     $this->output = new MockConsoleOutput($this, parent::getOutput()->getVerbosity());
     $this->logger = new ConsoleLogger($this->output);
+    $this->setAutoExit(FALSE);
   }
 
   /**
@@ -74,5 +77,12 @@ class MockJorge extends Jorge {
   public function log($level, $message, array $context = []) {
     $levelString = ($level === NULL) ? 'NULL' : $level;
     $this->messages[] = [$levelString, $message, $context];
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function run(InputInterface $input = NULL, OutputInterface $output = NULL) {
+    parent::run(NULL, $this->getOutput());
   }
 }


### PR DESCRIPTION

This branch adds [PHPUnit](https://phpunit.readthedocs.io/en/latest/index.html) as a dev dependency, plus 100 assertions across 14 tests.

Jorge is very dependent on the filesystem having certain things in place, so there are actually three sets of tests:

- `tests/JorgeDefaultTest.php` does a run in the current (Jorge project) directory and verifies that all the things that can be checked come out as expected. The biggest thing that can’t easily be checked is the output: Symfony makes it so you have to [inject a stream filter](https://stackoverflow.com/questions/39783811/test-output-to-php-stdout-with-phpunit) to even see it from inside another program.

- `tests/JorgePreTest.php` sets up temp directories (thanks to [Spatie’s Temporary Directory](https://github.com/spatie/temporary-directory) helper) with various possible states of config files to test how they affect the `configure()` method.

- `tests/JorgeTest.php` takes advantage of a `MockJorge` class that uses a `MockConsoleOutput` class to get ahold of the output without injecting a stream filter. It’s little more than a proof of concept right now (see comments at top of `tests/MockConsoleOutput.php`, but I can definitely imagine it will be useful to know we can rely on it when we start functional testing, too.

### Bug Fixes and API Changes

With all of that, also it fixes all the problems I found in Jorge.php when I was writing those tests, which makes some tweaks to the API.

- Jorge now exclusively uses `$this->log({level}, ...)` instead of `$this->logger->{level}(...)`.

- It was impossible for a tool name to be empty in `addTool()`, but it _was_ possible (and previously untested) for a tool to have a duplicate name, so I replaced that sanity check.

- API change: new method `allTools()` returns the array of tools. Should really only be used for testing.

- API change: `findRootPath()` is now `static`.

- API change: `getConfig()` without any parameters now returns the entire array of config values.

- API change: `getPath()` now returns `NULL` if you ask for a subdirectory that doesn’t exist.

- API change: `run()` returns a value (specifically, the return value from `parent::run()`).

- `sanitizePath()` is now `static` and a little smarter. I still feel like there’s more to do here.

- Composer and Git tools now no longer barf if we’re not running inside a Jorge project.

### Future Work

It is my goal to get unit tests to 100% coverage before the next (0.5.0) release, and hope that adding functional tests after that doesn’t cause any more API changes. One file down, nine to go (though only `src/Tool/Tool.php` is likely to be tricky). 
