### PR TITLE
Content option for Reset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ export PATH="$PATH:~/.composer/vendor/bin"
 
 In order for the new `PATH` to take effect, you can either log out and back in, or run `source .bash_profile` (or `source .profile`). You can test that it worked by running `cgr --help`; it should give you help instead of an error message.
 
-After all that, you should be able to run `cgr mtholyoke/jorge`. If it is successfully installed, `jorge --version` will report “Can’t find project root” and a version.
+After all that, you should be able to run `cgr mtholyoke/jorge:*`. If it is successfully installed, `jorge --version` will report “Can’t find project root” and a version. You can omit the `:*` if you only want the current version with no major upgrades, or replace the `*` with a specific version.
 
 
 ### For Development: Install with Git
@@ -41,11 +41,12 @@ Optionally, you may also have the key `include_config`, which specifies a list o
 
 ### Drupal 7 or 8 Configuration
 
-A config file may include the key `reset`, which contains a block that provides any of five optional parameters to the `reset` command (described below):
-- `branch  ` - Which Git branch to reset your current codebase to (default `master`)
-- `database` - Which Pantheon environment to copy the database from (default `dev`)
-- `files   ` - Which Pantheon environment to copy the files from (default `dev`)
-- `rsync   ` - Whether Lando should use `rsync` to copy files (default `TRUE`)
+A config file may include the key `reset`, which contains a block that provides any of seven optional parameters to the `reset` command (described below):
+- `branch  ` - Which Git branch to reset your current codebase to (default is `master`)
+- `content`  - Which Pantheon environment to copy database and files from (default is `dev`)
+- `database` - Which Pantheon environment to copy the database from (default matches `content`)
+- `files   ` - Which Pantheon environment to copy the files from (default matches `database`)
+- `rsync   ` - Whether Lando should use `rsync` to copy files (default is `TRUE`)
 - `username` - A username (usually an admin) that needs a local password (no default)
 - `password` - A local password for the username specified above (no default)
 
@@ -54,8 +55,7 @@ Commonly, the configuration committed to the project’s Git repo looks like thi
 appType: drupal8
 reset:
   branch: master
-  database: dev
-  files: dev
+  content: dev
   rsync: TRUE
 include_config:
   - local.yml
@@ -73,9 +73,9 @@ reset:
 
 ### `jorge drush `_`{drush-command}`_
 
-In a Composer-powered Drupal 8 project, `lando drush `_`{drush-command}`_ needs to be run inside the `web` directory (so it has access to Drupal), regardless of whether you’re currently in that directory. This command runs it from outside that directory, (after starting Lando if it’s not already running).
+In a Composer-powered Drupal 8 project, `lando drush `_`{drush-command}`_ may need to be run inside the `web` directory (so it has access to Drupal), regardless of whether you’re currently in that directory. This command lets you run it from outside that directory, (after starting Lando if it’s not already running).
 
-Accepts the `-y`/`--yes` and `-n`/`--no` option natively, but other Drush options need to be escaped. See `jorge help drush` for details. Note that `-n` is actually Symfony `--no-interaction`, which has approximately the same effect.
+It accepts the `-y`/`--yes` and `-n`/`--no` option natively, but other Drush options need to be escaped. See `jorge help drush` for details. Note that `-n` is actually Symfony `--no-interaction`, which has approximately the same effect.
 
 
 ### `jorge reset`
@@ -86,7 +86,7 @@ Starts Lando if it is not already running.
 
 Your project must be in a clean state: if Git can’t change branches, the whole thing will fail.
 
-Optionally takes command-line switches which will override those settings (except `rsync`); see `jorge help reset` for details.
+Optionally takes command-line switches which will override the settings described above (except `rsync`); see `jorge help reset` for details.
 
 If a username is provided but no password is supplied, Jorge will prompt you for one. If you leave that blank also, the password will not be reset.
 

--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ If a username is provided but no password is supplied, Jorge will prompt you for
 
 ## Future Work
 
-- Tests (see [Testing Commands](https://symfony.com/doc/current/console.html#testing-commands) for example)
+- More tests (see also Symfony doc [Testing Commands](https://symfony.com/doc/current/console.html#testing-commands))
+  - `Tool::exec()` uses the Symfony Process component when user interaction is required, and a first pass at testing by executing `read` with `-p "\nPress enter" x` did not provide the expected coverage. Possibly we need to do a full mock as in `ResetCommandTest::testInteract()`. and adjust `Tool::exec()` to use an `InputInterface` instead of `STDIN`.
 
-- Implement [Tools](src/Tool/) for Git, Lando, &c., using APIs or as service(s) within the container(s), for better awareness of initial/current state
 
-- Refactor the execution to take advantage of the implemented tools
+- Implement [Tools](src/Tool/) for Git, &c., using APIs or as service(s) within the container(s), for better awareness of initial/current state
+
+- Lando may not be a _Tool_; it may be a new kind of thing. Possibly we need a plugin interface for “environment manager”.
 
 - Option to stash or discard changes before a `git checkout`?
-
-- Replace `system()` and `exec()` calls with Symfony Process component (currently it gets tangled when Lando needs to `attach` to the Docker container)
 
 - Implement `jorge save` and refactor `jorge reset` to be able to use saved state
 

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -39,6 +39,7 @@ class ResetCommand extends Command {
       ->setName('reset')
       ->setDescription('Aligns code, database, and files to a specified state')
       ->addOption('branch',   'b', InputOption::VALUE_OPTIONAL, 'Git branch to use <fg=yellow>[default: "master"]</>')
+      ->addOption('content',  'c', InputOption::VALUE_OPTIONAL, 'Environment to load database and files from <fg=yellow>[default: "dev"]</>')
       ->addOption('database', 'd', InputOption::VALUE_OPTIONAL, 'Environment to load database from <fg=yellow>[default: "dev"]</>')
       ->addOption('files',    'f', InputOption::VALUE_OPTIONAL, 'Environment to copy files from <fg=yellow>[default: "dev"]</>')
       ->addOption('username', 'u', InputOption::VALUE_OPTIONAL, 'Admin account to have local password set')
@@ -49,8 +50,7 @@ class ResetCommand extends Command {
     # These can be set by config.yml, and set or overridden by command line options
     $this->params = [
       'branch'   => 'master',
-      'database' => 'dev',
-      'files'    => 'dev',
+      'content'  => 'dev',
       'rsync'    => TRUE,
       'username' => '',
       'password' => '',
@@ -76,6 +76,18 @@ class ResetCommand extends Command {
       if ($input->hasOption($var) && $input->getOption($var)) {
         $this->params[$var] = $input->getOption($var);
       }
+    }
+
+    // Specifying a database overrides specified or default content source.
+    // Specifying a file source overrides whichever of those is in effect.
+    $this->params['database'] = $this->params['content'];
+    $this->params['files']    = $this->params['content'];
+    if ($input->hasOption('database') && $input->getOption('database')) {
+      $this->params['database'] = $input->getOption('database');
+      $this->params['files'] =    $input->getOption('database');
+    }
+    if ($input->hasOption('files') && $input->getOption('files')) {
+      $this->params['files'] = $input->getOption('files');
     }
 
     $this->log(LogLevel::DEBUG, 'Parameters:');

--- a/tests/Command/ResetCommandTest.php
+++ b/tests/Command/ResetCommandTest.php
@@ -31,7 +31,7 @@ final class ResetCommandTest extends TestCase {
     $this->assertSame(0, count($arguments));
     $this->assertSame(0, $definition->getArgumentRequiredCount());
     $options = $definition->getOptions();
-    $this->assertSame(5, count($options));
+    $this->assertSame(6, count($options));
     $this->assertNotEmpty($command->getHelp());
     # testInitialize() checks $->params in a mock instance.
   }
@@ -42,14 +42,13 @@ final class ResetCommandTest extends TestCase {
 
     $command = new MockResetCommand();
     $command->setName('mockReset');
-    $this->assertSame(6, count($command->getParams()));
+    $this->assertSame(5, count($command->getParams()));
     $this->assertSame($command, $jorge->add($command));
 
     $appType = $this->makeRandomString();
     $reset = [
       'branch'   => $this->makeRandomString(),
-      'database' => $this->makeRandomString(),
-      'files'    => $this->makeRandomString(),
+      'content'  => $this->makeRandomString(),
       'rsync'    => $this->makeRandomBoolean(),
       'username' => $this->makeRandomString(),
       'password' => $this->makeRandomString(),
@@ -64,6 +63,8 @@ final class ResetCommandTest extends TestCase {
 
     # Make sure Jorge config is correctly applied:
     $this->assertSame($appType, $command->getAppType());
+    $reset['database'] = $reset['content'];
+    $reset['files']    = $reset['content'];
     $this->assertSame($reset, $command->getParams());
     $expect = [[LogLevel::DEBUG, '{mockReset} Parameters:']];
     foreach ($reset as $param => $value) {
@@ -74,6 +75,7 @@ final class ResetCommandTest extends TestCase {
 
     $options = [
       '--branch'   => $this->makeRandomString(),
+      '--content'  => $this->makeRandomString(),
       '--database' => $this->makeRandomString(),
       '--files'    => $this->makeRandomString(),
       '--username' => $this->makeRandomString(),
@@ -164,8 +166,7 @@ final class ResetCommandTest extends TestCase {
     # Set up params for a couple of runs:
     $simpleParams = [
       'branch'   => $this->makeRandomString(),
-      'database' => $this->makeRandomString(),
-      'files'    => $this->makeRandomString(),
+      'content'  => $this->makeRandomString(),
       'rsync'    => FALSE,
       'username' => '',
       'password' => '',
@@ -208,7 +209,7 @@ final class ResetCommandTest extends TestCase {
     $lando->expects($this->exactly(2))
           ->method('run')
           ->withConsecutive(
-              ['pull --code=none --database=' . $simpleParams['database'] . ' --files=' . $simpleParams['files']],
+              ['pull --code=none --database=' . $simpleParams['content'] . ' --files=' . $simpleParams['content']],
               ['pull --code=none --database=' . $complexParams['database'] . ' --files=' . $complexParams['files'] . ' --rsync']
             )
           ->willReturn(0);
@@ -281,8 +282,7 @@ final class ResetCommandTest extends TestCase {
     # Set up params for a couple of runs:
     $simpleParams = [
       'branch'   => $this->makeRandomString(),
-      'database' => $this->makeRandomString(),
-      'files'    => $this->makeRandomString(),
+      'content'  => $this->makeRandomString(),
       'rsync'    => FALSE,
       'username' => '',
       'password' => '',
@@ -334,7 +334,7 @@ final class ResetCommandTest extends TestCase {
     $lando->expects($this->exactly(2))
           ->method('run')
           ->withConsecutive(
-              ['pull --code=none --database=' . $simpleParams['database'] . ' --files=' . $simpleParams['files']],
+              ['pull --code=none --database=' . $simpleParams['content'] . ' --files=' . $simpleParams['content']],
               ['pull --code=none --database=' . $complexParams['database'] . ' --files=' . $complexParams['files'] . ' --rsync']
             )
           ->willReturn(0);

--- a/tests/Mock/MockResetCommand.php
+++ b/tests/Mock/MockResetCommand.php
@@ -87,6 +87,12 @@ class MockResetCommand extends ResetCommand {
    */
   public function setParams($params) {
     $this->params = $params;
+    if (isset($this->params['content']) && !isset($this->params['database'])) {
+      $this->params['database'] = $this->params['content'];
+    }
+    if (isset($this->params['database']) && !isset($this->params['files'])) {
+      $this->params['files'] = $this->params['database'];
+    }
     return $this;
   }
 }

--- a/tests/coverage.xml
+++ b/tests/coverage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1535288197">
-  <project timestamp="1535288197">
+<coverage generated="1535410437">
+  <project timestamp="1535410437">
     <package name="MountHolyoke\Jorge\Command">
       <file name="/Users/jproctor/Projects/jorge/src/Command/DrushCommand.php">
         <class name="MountHolyoke\Jorge\Command\DrushCommand" namespace="MountHolyoke\Jorge\Command">
@@ -74,7 +74,7 @@
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Command/ResetCommand.php">
         <class name="MountHolyoke\Jorge\Command\ResetCommand" namespace="MountHolyoke\Jorge\Command">
-          <metrics complexity="27" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="96" coveredstatements="96" elements="102" coveredelements="102"/>
+          <metrics complexity="31" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="110" coveredelements="110"/>
         </class>
         <line num="37" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="24"/>
         <line num="39" type="stmt" count="24"/>
@@ -85,9 +85,10 @@
         <line num="44" type="stmt" count="24"/>
         <line num="45" type="stmt" count="24"/>
         <line num="46" type="stmt" count="24"/>
-        <line num="50" type="stmt" count="24"/>
+        <line num="47" type="stmt" count="24"/>
+        <line num="51" type="stmt" count="24"/>
         <line num="58" type="stmt" count="24"/>
-        <line num="68" type="method" name="initialize" visibility="protected" complexity="6" crap="6" count="3"/>
+        <line num="68" type="method" name="initialize" visibility="protected" complexity="10" crap="10" count="3"/>
         <line num="69" type="stmt" count="3"/>
         <line num="70" type="stmt" count="3"/>
         <line num="71" type="stmt" count="3"/>
@@ -96,89 +97,96 @@
         <line num="74" type="stmt" count="2"/>
         <line num="76" type="stmt" count="3"/>
         <line num="77" type="stmt" count="3"/>
-        <line num="81" type="stmt" count="3"/>
-        <line num="82" type="stmt" count="3"/>
         <line num="83" type="stmt" count="3"/>
+        <line num="84" type="stmt" count="3"/>
         <line num="85" type="stmt" count="3"/>
-        <line num="96" type="method" name="interact" visibility="protected" complexity="3" crap="3" count="1"/>
-        <line num="97" type="stmt" count="1"/>
-        <line num="98" type="stmt" count="1"/>
-        <line num="99" type="stmt" count="1"/>
-        <line num="102" type="stmt" count="1"/>
-        <line num="104" type="stmt" count="1"/>
-        <line num="115" type="method" name="execute" visibility="protected" complexity="5" crap="5" count="3"/>
-        <line num="116" type="stmt" count="3"/>
-        <line num="117" type="stmt" count="3"/>
-        <line num="118" type="stmt" count="1"/>
-        <line num="120" type="stmt" count="2"/>
-        <line num="121" type="stmt" count="1"/>
-        <line num="123" type="stmt" count="1"/>
-        <line num="125" type="stmt" count="1"/>
-        <line num="126" type="stmt" count="1"/>
-        <line num="127" type="stmt" count="1"/>
-        <line num="128" type="stmt" count="1"/>
-        <line num="129" type="stmt" count="1"/>
-        <line num="131" type="stmt" count="1"/>
-        <line num="132" type="stmt" count="1"/>
+        <line num="86" type="stmt" count="1"/>
+        <line num="87" type="stmt" count="1"/>
+        <line num="89" type="stmt" count="3"/>
+        <line num="90" type="stmt" count="1"/>
+        <line num="93" type="stmt" count="3"/>
+        <line num="94" type="stmt" count="3"/>
+        <line num="95" type="stmt" count="3"/>
+        <line num="97" type="stmt" count="3"/>
+        <line num="108" type="method" name="interact" visibility="protected" complexity="3" crap="3" count="1"/>
+        <line num="109" type="stmt" count="1"/>
+        <line num="110" type="stmt" count="1"/>
+        <line num="111" type="stmt" count="1"/>
+        <line num="114" type="stmt" count="1"/>
+        <line num="116" type="stmt" count="1"/>
+        <line num="127" type="method" name="execute" visibility="protected" complexity="5" crap="5" count="3"/>
+        <line num="128" type="stmt" count="3"/>
+        <line num="129" type="stmt" count="3"/>
+        <line num="130" type="stmt" count="1"/>
+        <line num="132" type="stmt" count="2"/>
         <line num="133" type="stmt" count="1"/>
-        <line num="134" type="stmt" count="1"/>
-        <line num="136" type="stmt" count="1"/>
+        <line num="135" type="stmt" count="1"/>
+        <line num="137" type="stmt" count="1"/>
         <line num="138" type="stmt" count="1"/>
-        <line num="151" type="method" name="executeDrupal7" visibility="protected" complexity="6" crap="6" count="1"/>
-        <line num="152" type="stmt" count="1"/>
-        <line num="153" type="stmt" count="1"/>
-        <line num="156" type="stmt" count="1"/>
-        <line num="157" type="stmt" count="1"/>
-        <line num="158" type="stmt" count="1"/>
-        <line num="159" type="stmt" count="1"/>
-        <line num="161" type="stmt" count="1"/>
-        <line num="162" type="stmt" count="1"/>
-        <line num="163" type="stmt" count="1"/>
+        <line num="139" type="stmt" count="1"/>
+        <line num="140" type="stmt" count="1"/>
+        <line num="141" type="stmt" count="1"/>
+        <line num="143" type="stmt" count="1"/>
+        <line num="144" type="stmt" count="1"/>
+        <line num="145" type="stmt" count="1"/>
+        <line num="146" type="stmt" count="1"/>
+        <line num="148" type="stmt" count="1"/>
+        <line num="150" type="stmt" count="1"/>
+        <line num="163" type="method" name="executeDrupal7" visibility="protected" complexity="6" crap="6" count="1"/>
         <line num="164" type="stmt" count="1"/>
         <line num="165" type="stmt" count="1"/>
-        <line num="166" type="stmt" count="1"/>
         <line num="168" type="stmt" count="1"/>
+        <line num="169" type="stmt" count="1"/>
         <line num="170" type="stmt" count="1"/>
         <line num="171" type="stmt" count="1"/>
-        <line num="172" type="stmt" count="1"/>
+        <line num="173" type="stmt" count="1"/>
         <line num="174" type="stmt" count="1"/>
         <line num="175" type="stmt" count="1"/>
         <line num="176" type="stmt" count="1"/>
-        <line num="179" type="stmt" count="1"/>
+        <line num="177" type="stmt" count="1"/>
+        <line num="178" type="stmt" count="1"/>
+        <line num="180" type="stmt" count="1"/>
         <line num="182" type="stmt" count="1"/>
         <line num="183" type="stmt" count="1"/>
         <line num="184" type="stmt" count="1"/>
-        <line num="185" type="stmt" count="1"/>
+        <line num="186" type="stmt" count="1"/>
         <line num="187" type="stmt" count="1"/>
-        <line num="198" type="method" name="executeDrupal8" visibility="protected" complexity="6" crap="6" count="1"/>
+        <line num="188" type="stmt" count="1"/>
+        <line num="191" type="stmt" count="1"/>
+        <line num="194" type="stmt" count="1"/>
+        <line num="195" type="stmt" count="1"/>
+        <line num="196" type="stmt" count="1"/>
+        <line num="197" type="stmt" count="1"/>
         <line num="199" type="stmt" count="1"/>
-        <line num="200" type="stmt" count="1"/>
-        <line num="201" type="stmt" count="1"/>
-        <line num="204" type="stmt" count="1"/>
-        <line num="205" type="stmt" count="1"/>
-        <line num="206" type="stmt" count="1"/>
-        <line num="207" type="stmt" count="1"/>
-        <line num="209" type="stmt" count="1"/>
-        <line num="210" type="stmt" count="1"/>
+        <line num="210" type="method" name="executeDrupal8" visibility="protected" complexity="6" crap="6" count="1"/>
         <line num="211" type="stmt" count="1"/>
         <line num="212" type="stmt" count="1"/>
         <line num="213" type="stmt" count="1"/>
-        <line num="214" type="stmt" count="1"/>
-        <line num="215" type="stmt" count="1"/>
+        <line num="216" type="stmt" count="1"/>
         <line num="217" type="stmt" count="1"/>
-        <line num="220" type="stmt" count="1"/>
+        <line num="218" type="stmt" count="1"/>
+        <line num="219" type="stmt" count="1"/>
+        <line num="221" type="stmt" count="1"/>
+        <line num="222" type="stmt" count="1"/>
+        <line num="223" type="stmt" count="1"/>
         <line num="224" type="stmt" count="1"/>
         <line num="225" type="stmt" count="1"/>
+        <line num="226" type="stmt" count="1"/>
         <line num="227" type="stmt" count="1"/>
-        <line num="228" type="stmt" count="1"/>
         <line num="229" type="stmt" count="1"/>
-        <line num="233" type="stmt" count="1"/>
-        <line num="235" type="stmt" count="1"/>
+        <line num="232" type="stmt" count="1"/>
         <line num="236" type="stmt" count="1"/>
         <line num="237" type="stmt" count="1"/>
-        <line num="238" type="stmt" count="1"/>
+        <line num="239" type="stmt" count="1"/>
         <line num="240" type="stmt" count="1"/>
-        <metrics loc="241" ncloc="169" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="96" coveredstatements="96" elements="102" coveredelements="102"/>
+        <line num="241" type="stmt" count="1"/>
+        <line num="245" type="stmt" count="1"/>
+        <line num="247" type="stmt" count="1"/>
+        <line num="248" type="stmt" count="1"/>
+        <line num="249" type="stmt" count="1"/>
+        <line num="250" type="stmt" count="1"/>
+        <line num="252" type="stmt" count="1"/>
+        <metrics loc="253" ncloc="177" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="110" coveredelements="110"/>
       </file>
     </package>
     <package name="MountHolyoke\Jorge\Helper">
@@ -619,6 +627,6 @@
         <metrics loc="320" ncloc="191" classes="1" methods="20" coveredmethods="19" conditionals="0" coveredconditionals="0" statements="84" coveredstatements="76" elements="104" coveredelements="95"/>
       </file>
     </package>
-    <metrics files="10" loc="1535" ncloc="1000" classes="10" methods="65" coveredmethods="64" conditionals="0" coveredconditionals="0" statements="485" coveredstatements="477" elements="550" coveredelements="541"/>
+    <metrics files="10" loc="1547" ncloc="1008" classes="10" methods="65" coveredmethods="64" conditionals="0" coveredconditionals="0" statements="493" coveredstatements="485" elements="558" coveredelements="549"/>
   </project>
 </coverage>


### PR DESCRIPTION

This branch adds a `-c`/`--content` option for the `reset` command, to explicitly specify the database and file source for the reset as one switch.

It also changes the behavior of the file source selection: if none is specified, it uses whatever it's using for the database (whether that’s specified explicitly, getting it from `--content`, or falling through to default `dev`).
