### PR TITLE
Lando update

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can also clone this repo for development and run Jorge directly from that co
 ```bash
 ln -s ~/Projects/jorge/bin/jorge /usr/local/bin/jorge
 ```
+Run `composer install` in the Jorge directory to get its dependencies.
 
 If you're going to do any development, also run `bin/setup.sh` once to install the standard Git hooks.
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ If an admin account username is provided but no password is supplied, Jorge will
 
 ## Future Work
 
+- Make sure Drush is installed and working before relying on it.
+
 - More tests (see also Symfony doc [Testing Commands](https://symfony.com/doc/current/console.html#testing-commands))
   - `Tool::exec()` uses the Symfony Process component when user interaction is required, and a first pass at testing by executing `read` with `-p "\nPress enter" x` did not provide the expected coverage. Possibly we need to do a full mock as in `ResetCommandTest::testInteract()` and adjust `Tool::exec()` to use an `InputInterface` instead of `STDIN`.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Jorge is an experimental command-line tool for managing the complex interaction 
 
 **Note:** Jorge stores no connection information about the various services and does not provide any additional permission; your account must already have access (ideally via SSH key or token) to the various projects on GitHub and Pantheon, and Jorge works on your behalf using those credentials.
 
+
 ## Installation
 
 ### Recommended: Install with Composer/CGR
@@ -29,6 +30,7 @@ ln -s ~/Projects/jorge/bin/jorge /usr/local/bin/jorge
 
 If you're going to do any development, also run `bin/setup.sh` once to install the standard Git hooks.
 
+
 ## Configuration
 
 Jorge has no global configuration; it works on the project level only.
@@ -39,11 +41,13 @@ In `.jorge/config.yml`, you **must** have the key `appType`. Currently, only `dr
 
 Optionally, you may also have the key `include_config`, which specifies a list of additional configuration files to include from the `.jorge` directory, to be loaded in the order specified. Values in those files will override any previously loaded settings, including the main `config.yml`. Note that `include_config` is only allowed in the main `config.yml` file.
 
+
 ### Drupal 7 or 8 Configuration
 
 A config file may include the key `reset`, which contains a block that provides any of seven optional parameters to the `reset` command (described below):
+- `auth    ` - A Terminus machine token to authenticate with Pantheon for the reset
 - `branch  ` - Which Git branch to reset your current codebase to (default is `master`)
-- `content`  - Which Pantheon environment to copy database and files from (default is `dev`)
+- `content ` - Which Pantheon environment to copy database and files from (default is `dev`)
 - `database` - Which Pantheon environment to copy the database from (default matches `content`)
 - `files   ` - Which Pantheon environment to copy the files from (default matches `database`)
 - `rsync   ` - Whether Lando should use `rsync` to copy files (default is `TRUE`)
@@ -64,6 +68,7 @@ include_config:
 In `local.yml`, which is _not_ committed to the project’s Git repo:
 ```yml
 reset:
+  auth: a1b2c3d4e5f6
   username: admin
   password: asdf1234
 ```
@@ -82,13 +87,13 @@ It accepts the `-y`/`--yes` and `-n`/`--no` option natively, but other Drush opt
 
 Sets up the local development environment as specified in the configuration file(s) described above.
 
-Starts Lando if it is not already running.
+**Note:** Your project must be in a clean state: if Git can’t change branches, the whole thing will fail. Lando versions starting with 3.0.0-rc.2 (released 1 Feb 2019) require a Terminus machine token be present in the `auth` parameter (command line or config file); without this, the whole thing will fail.
 
-Your project must be in a clean state: if Git can’t change branches, the whole thing will fail.
+Starts Lando if it is not already running, then uses `lando pull` to fetch the site from Pantheon.
 
 Optionally takes command-line switches which will override the settings described above (except `rsync`); see `jorge help reset` for details.
 
-If a username is provided but no password is supplied, Jorge will prompt you for one. If you leave that blank also, the password will not be reset.
+If an admin account username is provided but no password is supplied, Jorge will prompt you for one. If you leave that blank also, the password will not be reset.
 
 
 ### _Not Implemented Yet_
@@ -99,8 +104,10 @@ If a username is provided but no password is supplied, Jorge will prompt you for
 ## Future Work
 
 - More tests (see also Symfony doc [Testing Commands](https://symfony.com/doc/current/console.html#testing-commands))
-  - `Tool::exec()` uses the Symfony Process component when user interaction is required, and a first pass at testing by executing `read` with `-p "\nPress enter" x` did not provide the expected coverage. Possibly we need to do a full mock as in `ResetCommandTest::testInteract()`. and adjust `Tool::exec()` to use an `InputInterface` instead of `STDIN`.
+  - `Tool::exec()` uses the Symfony Process component when user interaction is required, and a first pass at testing by executing `read` with `-p "\nPress enter" x` did not provide the expected coverage. Possibly we need to do a full mock as in `ResetCommandTest::testInteract()` and adjust `Tool::exec()` to use an `InputInterface` instead of `STDIN`.
 
+
+- Lando 3.0.0-rc.2 and later have an interactive auth system for commands that require it (such as `lando pull`, which is the heart of `jorge reset`). It would be nice to be able to pass this through to the user if they don’t have the token in their `local.yml` config file. These versions of Lando can also read the environment variable `TERMINUS_TOKEN`, so we should also check for that.
 
 - Implement [Tools](src/Tool/) for Git, &c., using APIs or as service(s) within the container(s), for better awareness of initial/current state
 

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "composer/ca-bundle",
-            "version": "1.1.2",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "46afded9720f40b9dc63542af4e3e43a1177acb0"
+                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/46afded9720f40b9dc63542af4e3e43a1177acb0",
-                "reference": "46afded9720f40b9dc63542af4e3e43a1177acb0",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
+                "reference": "558f321c52faeb4828c03e7dc0cfe39a09e09a2d",
                 "shasum": ""
             },
             "require": {
@@ -60,20 +60,20 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2018-08-08T08:57:40+00:00"
+            "time": "2019-01-28T09:30:10+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "1.7.2",
+            "version": "1.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "576aab9b5abb2ed11a1c52353a759363216a4ad2"
+                "reference": "bc364c2480c17941e2135cfc568fa41794392534"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/576aab9b5abb2ed11a1c52353a759363216a4ad2",
-                "reference": "576aab9b5abb2ed11a1c52353a759363216a4ad2",
+                "url": "https://api.github.com/repos/composer/composer/zipball/bc364c2480c17941e2135cfc568fa41794392534",
+                "reference": "bc364c2480c17941e2135cfc568fa41794392534",
                 "shasum": ""
             },
             "require": {
@@ -109,7 +109,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.7-dev"
+                    "dev-master": "1.8-dev"
                 }
             },
             "autoload": {
@@ -140,7 +140,7 @@
                 "dependency",
                 "package"
             ],
-            "time": "2018-08-16T14:57:12+00:00"
+            "time": "2019-02-11T09:52:10+00:00"
         },
         {
             "name": "composer/semver",
@@ -206,16 +206,16 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "cb17687e9f936acd7e7245ad3890f953770dec1b"
+                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/cb17687e9f936acd7e7245ad3890f953770dec1b",
-                "reference": "cb17687e9f936acd7e7245ad3890f953770dec1b",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
+                "reference": "7a9556b22bd9d4df7cad89876b00af58ef20d3a2",
                 "shasum": ""
             },
             "require": {
@@ -263,20 +263,20 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2018-04-30T10:33:04+00:00"
+            "time": "2018-11-01T09:45:54+00:00"
         },
         {
             "name": "composer/xdebug-handler",
-            "version": "1.2.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/xdebug-handler.git",
-                "reference": "e37cbd80da64afe314c72de8d2d2fec0e40d9373"
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/e37cbd80da64afe314c72de8d2d2fec0e40d9373",
-                "reference": "e37cbd80da64afe314c72de8d2d2fec0e40d9373",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/d17708133b6c276d6e42ef887a877866b909d892",
+                "reference": "d17708133b6c276d6e42ef887a877866b909d892",
                 "shasum": ""
             },
             "require": {
@@ -307,7 +307,7 @@
                 "Xdebug",
                 "performance"
             ],
-            "time": "2018-08-23T12:00:19+00:00"
+            "time": "2019-01-28T20:25:53+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/composer.lock
+++ b/composer.lock
@@ -517,25 +517,29 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.1.3",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "ca80b8ced97cf07390078b29773dc384c39eee1f"
+                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/ca80b8ced97cf07390078b29773dc384c39eee1f",
-                "reference": "ca80b8ced97cf07390078b29773dc384c39eee1f",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
+                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1.3",
+                "symfony/contracts": "^1.0",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/dependency-injection": "<3.4",
                 "symfony/process": "<3.3"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
@@ -546,7 +550,7 @@
                 "symfony/process": "~3.4|~4.0"
             },
             "suggest": {
-                "psr/log-implementation": "For using the console logger",
+                "psr/log": "For using the console logger",
                 "symfony/event-dispatcher": "",
                 "symfony/lock": "",
                 "symfony/process": ""
@@ -554,7 +558,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -581,20 +585,88 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-01-25T14:35:16+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v4.1.3",
+            "name": "symfony/contracts",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "2e30335e0aafeaa86645555959572fe7cea22b43"
+                "url": "https://github.com/symfony/contracts.git",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/2e30335e0aafeaa86645555959572fe7cea22b43",
-                "reference": "2e30335e0aafeaa86645555959572fe7cea22b43",
+                "url": "https://api.github.com/repos/symfony/contracts/zipball/1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "reference": "1aa7ab2429c3d594dd70689604b5cf7421254cdf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "psr/cache": "^1.0",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "psr/cache": "When using the Cache contracts",
+                "psr/container": "When using the Service contracts",
+                "symfony/cache-contracts-implementation": "",
+                "symfony/service-contracts-implementation": "",
+                "symfony/translation-contracts-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\": ""
+                },
+                "exclude-from-classmap": [
+                    "**/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A set of abstractions extracted out of the Symfony components",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2018-12-05T08:06:11+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v4.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "7c16ebc2629827d4ec915a52ac809768d060a4ee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7c16ebc2629827d4ec915a52ac809768d060a4ee",
+                "reference": "7c16ebc2629827d4ec915a52ac809768d060a4ee",
                 "shasum": ""
             },
             "require": {
@@ -604,7 +676,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -631,20 +703,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-01-16T20:35:37+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.1.3",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e162f1df3102d0b7472805a5a9d5db9fcf0a8068"
+                "reference": "ef71816cbb264988bb57fe6a73f610888b9aa70c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e162f1df3102d0b7472805a5a9d5db9fcf0a8068",
-                "reference": "e162f1df3102d0b7472805a5a9d5db9fcf0a8068",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ef71816cbb264988bb57fe6a73f610888b9aa70c",
+                "reference": "ef71816cbb264988bb57fe6a73f610888b9aa70c",
                 "shasum": ""
             },
             "require": {
@@ -653,7 +725,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -680,11 +752,11 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-01-16T20:35:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -742,16 +814,16 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.9.0",
+            "version": "v1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
-                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/c79c051f5b3a46be09205c73b80b346e4153e494",
+                "reference": "c79c051f5b3a46be09205c73b80b346e4153e494",
                 "shasum": ""
             },
             "require": {
@@ -797,20 +869,20 @@
                 "portable",
                 "shim"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2018-09-21T13:07:52+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v4.1.3",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "f01fc7a4493572f7f506c49dcb50ad01fb3a2f56"
+                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/f01fc7a4493572f7f506c49dcb50ad01fb3a2f56",
-                "reference": "f01fc7a4493572f7f506c49dcb50ad01fb3a2f56",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
+                "reference": "6c05edb11fbeff9e2b324b4270ecb17911a8b7ad",
                 "shasum": ""
             },
             "require": {
@@ -819,7 +891,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -846,20 +918,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-01-24T22:05:03+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.1.3",
+            "version": "v4.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "46bc69aa91fc4ab78a96ce67873a6b0c148fd48c"
+                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/46bc69aa91fc4ab78a96ce67873a6b0c148fd48c",
-                "reference": "46bc69aa91fc4ab78a96ce67873a6b0c148fd48c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/d461670ee145092b7e2a56c1da7118f19cadadb0",
+                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0",
                 "shasum": ""
             },
             "require": {
@@ -878,7 +950,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -905,7 +977,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-07-26T11:24:31+00:00"
+            "time": "2019-01-16T20:35:37+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -311,23 +311,23 @@
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.2.7",
+            "version": "5.2.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/justinrainbow/json-schema.git",
-                "reference": "8560d4314577199ba51bf2032f02cd1315587c23"
+                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/8560d4314577199ba51bf2032f02cd1315587c23",
-                "reference": "8560d4314577199ba51bf2032f02cd1315587c23",
+                "url": "https://api.github.com/repos/justinrainbow/json-schema/zipball/dcb6e1006bb5fd1e392b4daa68932880f37550d4",
+                "reference": "dcb6e1006bb5fd1e392b4daa68932880f37550d4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.1",
+                "friendsofphp/php-cs-fixer": "~2.2.20",
                 "json-schema/json-schema-test-suite": "1.2.0",
                 "phpunit/phpunit": "^4.8.35"
             },
@@ -373,20 +373,20 @@
                 "json",
                 "schema"
             ],
-            "time": "2018-02-14T22:26:30+00:00"
+            "time": "2019-01-14T23:55:14+00:00"
         },
         {
             "name": "psr/log",
-            "version": "1.0.2",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
+                "reference": "6c001f1daafa3a3ac1d8ff69ee4db8e799a654dd",
                 "shasum": ""
             },
             "require": {
@@ -420,7 +420,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10T12:19:37+00:00"
+            "time": "2018-11-20T15:27:04+00:00"
         },
         {
             "name": "seld/jsonlint",

--- a/composer.lock
+++ b/composer.lock
@@ -1402,16 +1402,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "6.0.7",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/865662550c384bc1db7e51d29aeda1c2c161d69a",
-                "reference": "865662550c384bc1db7e51d29aeda1c2c161d69a",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
@@ -1422,7 +1422,7 @@
                 "phpunit/php-text-template": "^1.2.1",
                 "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
@@ -1435,7 +1435,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.0-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -1461,24 +1461,27 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-06-01T07:51:50+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cecbc684605bb0cc288828eb5d65d93d5c676d3c"
+                "reference": "050bedf145a257b1ff02746c31894800e5122946"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cecbc684605bb0cc288828eb5d65d93d5c676d3c",
-                "reference": "cecbc684605bb0cc288828eb5d65d93d5c676d3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/050bedf145a257b1ff02746c31894800e5122946",
+                "reference": "050bedf145a257b1ff02746c31894800e5122946",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "extra": {
@@ -1508,7 +1511,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2018-06-11T11:44:00+00:00"
+            "time": "2018-09-13T20:33:42+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -1602,16 +1605,16 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
-                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
                 "shasum": ""
             },
             "require": {
@@ -1647,20 +1650,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-02-01T13:16:43+00:00"
+            "time": "2018-10-30T05:52:18+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.3.2",
+            "version": "7.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "34705f81bddc3f505b9599a2ef96e2b4315ba9b8"
+                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/34705f81bddc3f505b9599a2ef96e2b4315ba9b8",
-                "reference": "34705f81bddc3f505b9599a2ef96e2b4315ba9b8",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
+                "reference": "09c85e14994df92e5ff1f5ec0b481bdb7d3d3df9",
                 "shasum": ""
             },
             "require": {
@@ -1681,11 +1684,11 @@
                 "phpunit/php-timer": "^2.0",
                 "sebastian/comparator": "^3.0",
                 "sebastian/diff": "^3.0",
-                "sebastian/environment": "^3.1",
+                "sebastian/environment": "^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
             },
             "conflict": {
@@ -1705,7 +1708,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "7.3-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -1731,7 +1734,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-08-22T06:39:21+00:00"
+            "time": "2019-02-18T09:24:50+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1844,23 +1847,23 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "366541b989927187c4ca70490a35615d3fef2dce"
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/366541b989927187c4ca70490a35615d3fef2dce",
-                "reference": "366541b989927187c4ca70490a35615d3fef2dce",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
+                "reference": "720fcc7e9b5cf384ea68d9d930d480907a0c1a29",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.0",
+                "phpunit/phpunit": "^7.5 || ^8.0",
                 "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
@@ -1896,32 +1899,35 @@
                 "unidiff",
                 "unified diff"
             ],
-            "time": "2018-06-10T07:54:39+00:00"
+            "time": "2019-02-04T06:01:07+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6fda8ce1974b62b14935adc02a9ed38252eca656",
+                "reference": "6fda8ce1974b62b14935adc02a9ed38252eca656",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
@@ -1946,7 +1952,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "time": "2019-02-01T05:27:49+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -2213,25 +2219,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
+                "reference": "4d7a795d35b889bf80a0cc04e08d77cedfa917a9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": "^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -2251,7 +2257,7 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "time": "2018-10-04T04:07:39+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2384,20 +2390,21 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a"
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/0df1908962e7a3071564e857d86874dad1ef204a",
-                "reference": "0df1908962e7a3071564e857d86874dad1ef204a",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^5.3.3 || ^7.0",
+                "symfony/polyfill-ctype": "^1.8"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.6",
@@ -2430,7 +2437,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-01-29T19:49:41+00:00"
+            "time": "2018-12-25T11:19:39+00:00"
         }
     ],
     "aliases": [],

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,8 +17,8 @@
     </whitelist>
   </filter>
 
-  <!--logging>
+  <!-- <logging>
     <log type="coverage-clover" target="tests/coverage.xml"/>
     <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
-  </logging-->
+  </logging> -->
 </phpunit>

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -38,6 +38,7 @@ class ResetCommand extends Command {
     $this
       ->setName('reset')
       ->setDescription('Aligns code, database, and files to a specified state')
+      ->addOption('auth',     'a', InputOption::VALUE_OPTIONAL, 'Terminus machine token to use')
       ->addOption('branch',   'b', InputOption::VALUE_OPTIONAL, 'Git branch to use <fg=yellow>[default: "master"]</>')
       ->addOption('content',  'c', InputOption::VALUE_OPTIONAL, 'Environment to load database and files from <fg=yellow>[default: "dev"]</>')
       ->addOption('database', 'd', InputOption::VALUE_OPTIONAL, 'Environment to load database from <fg=yellow>[default: "dev"]</>')
@@ -49,6 +50,7 @@ class ResetCommand extends Command {
 
     # These can be set by config.yml, and set or overridden by command line options
     $this->params = [
+      'auth'     => '',
       'branch'   => 'master',
       'content'  => 'dev',
       'rsync'    => TRUE,
@@ -177,6 +179,13 @@ class ResetCommand extends Command {
     if ($this->params['rsync']) {
       $lando_pull .= ' --rsync';
     }
+    if ($lando->needsAuth()) {
+      if (empty($this->params['auth'])) {
+        $this->log(LogLevel::ERROR, "This version of Lando requires an auth token to pull. Aborting.");
+        return 1;
+      }
+      $lando_pull .= ' --auth=' . $this->params['auth'];
+    }
     $lando->run($lando_pull);
 
     $drushSequence = [['drush_command' => ['cc', 'all']]];
@@ -225,6 +234,13 @@ class ResetCommand extends Command {
     $lando_pull = 'pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
     if ($this->params['rsync']) {
       $lando_pull .= ' --rsync';
+    }
+    if ($lando->needsAuth()) {
+      if (empty($this->params['auth'])) {
+        $this->log(LogLevel::ERROR, "This version of Lando requires an auth token to pull. Aborting.");
+        return 1;
+      }
+      $lando_pull .= ' --auth=' . $this->params['auth'];
     }
     $lando->run($lando_pull);
 

--- a/src/Tool/LandoTool.php
+++ b/src/Tool/LandoTool.php
@@ -71,7 +71,27 @@ class LandoTool extends Tool {
   }
 
   /**
+   * Checks the version to see if an auth token is required to pull.
+   *
+   * TODO: check for TERMINUS_TOKEN in environment.
+   * TODO: consolidate regex with parseLandoList.
+   *
+   * @return boolean
+   */
+  protected function needsAuth() {
+    $version_regex = '/^v3\.0\.0-rc\.(\d+)$/';
+    if (preg_match($version_regex, $this->version, $matches)) {
+      if ($matches[1] >= 2) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
    * Parse the output from `lando list`, which is not quite JSON.
+   *
+   * TODO: consolidate regex with needsAuth.
    *
    * @param array $lines Raw output from `lando list`
    * @return array

--- a/src/Tool/LandoTool.php
+++ b/src/Tool/LandoTool.php
@@ -78,7 +78,7 @@ class LandoTool extends Tool {
    *
    * @return boolean
    */
-  protected function needsAuth() {
+  public function needsAuth() {
     $version_regex = '/^v3\.0\.0-rc\.(\d+)$/';
     if (preg_match($version_regex, $this->version, $matches)) {
       if ($matches[1] >= 2) {

--- a/tests/Mock/MockLandoTool.php
+++ b/tests/Mock/MockLandoTool.php
@@ -171,6 +171,13 @@ class MockLandoTool extends LandoTool {
   /**
    * {@inheritDoc}
    */
+  public function needsAuth() {
+    return parent::needsAuth();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   public function parseLandoList(array $lines = []) {
     return parent::parseLandoList($lines);
   }

--- a/tests/Mock/MockLandoTool.php
+++ b/tests/Mock/MockLandoTool.php
@@ -48,7 +48,47 @@ class MockLandoTool extends LandoTool {
 
     # Establish mocked responses.
     $fixtures = [];
-    # 0 testRequireStarted calls exec('list') to test when lando is not running
+
+    # 0 testRequireStarted calls exec('version'); first time should fail.
+    $fixtures[] = [
+      'status' => 1,
+    ];
+
+    # 1a testRequireStarted calls exec('version'); second time should be weird.
+    $fixtures[] = [
+      'output' => ['v2.71828'],
+      'status' => 0,
+    ];
+    # 1b testRequireStarted calls exec('list')
+    $fixtures[] = [
+      'output' => ['{}'],
+      'status' => 0,
+    ];
+    # 1c testRequireStarted calls run('start')
+    $fixtures[] = ['status' => 0];
+    # 1d testRequireStarted calls exec('list')
+    $fixtures[] = [
+      'output' => [
+        '{',
+        $this->project . ': [',
+        '{',
+        "key: 'value',",
+        'array: [',
+        "'element'",
+        ']',
+        '}',
+        ']',
+        '}',
+      ],
+      'status' => 0,
+    ];
+
+    # 2a testRequireStarted calls exec('version'); this should be valid.
+    $fixtures[] = [
+      'output' => ['v3.0.0-beta.36'],
+      'status' => 0,
+    ];
+    # 2b testRequireStarted calls exec('list')
     $fixtures[] = [
       'output' => [
         '{',
@@ -58,9 +98,9 @@ class MockLandoTool extends LandoTool {
       ],
       'status' => 0,
     ];
-    # 1 testRequireStarted calls run('start')
+    # 2c testRequireStarted calls run('start')
     $fixtures[] = ['status' => 0];
-    # 2 testRequireStarted calls exec('list')
+    # 2d testRequireStarted calls exec('list')
     $fixtures[] = [
       'output' => [
         '{',
@@ -70,6 +110,7 @@ class MockLandoTool extends LandoTool {
       ],
       'status' => 0,
     ];
+
     # 3 testRequireStarted calls exec('list') to test when lando is already running
     $fixtures[] = [
       'output' => [
@@ -80,6 +121,7 @@ class MockLandoTool extends LandoTool {
       ],
       'status' => 0,
     ];
+
     # 4 testUpdateStatus calls exec('list') to test disabled tool
     $fixtures[] = [
       'output' => [
@@ -90,6 +132,7 @@ class MockLandoTool extends LandoTool {
       ],
       'status' => 0,
     ];
+
     # 5 testUpdateStatus calls exec('list') to test bad exit code
     $fixtures[] = [
       'output' => [
@@ -100,6 +143,7 @@ class MockLandoTool extends LandoTool {
       ],
       'status' => 1,
     ];
+
     # 6 testUpdateStatus calls exec('list') to test name mismatch
     $fixtures[] = [
       'output' => [
@@ -116,9 +160,27 @@ class MockLandoTool extends LandoTool {
   }
 
   /**
+   * Gets the version so we can test requireStarted().
+   *
+   * @return string
+   */
+  public function getVersion() {
+    return $this->version;
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function parseLandoList(array $lines = []) {
     return parent::parseLandoList($lines);
+  }
+
+  /**
+   * Sets the version so we can test parseLandoList().
+   *
+   * @param string $version The version this tool reports.
+   */
+  public function setVersion($version) {
+    $this->version = $version;
   }
 }

--- a/tests/Mock/MockLandoTool.php
+++ b/tests/Mock/MockLandoTool.php
@@ -171,13 +171,6 @@ class MockLandoTool extends LandoTool {
   /**
    * {@inheritDoc}
    */
-  public function needsAuth() {
-    return parent::needsAuth();
-  }
-
-  /**
-   * {@inheritDoc}
-   */
   public function parseLandoList(array $lines = []) {
     return parent::parseLandoList($lines);
   }

--- a/tests/Tool/LandoToolTest.php
+++ b/tests/Tool/LandoToolTest.php
@@ -65,6 +65,16 @@ final class LandoToolTest extends TestCase {
     $this->verifyMessages($expect, $messages);
   }
 
+  public function testNeedsAuth() {
+    $tool = new MockLandoTool();
+    $tool->setVersion('v3.0.0-beta.36');
+    $this->assertFalse($tool->needsAuth());
+    $tool->setVersion('v3.0.0-rc.1');
+    $this->assertFalse($tool->needsAuth());
+    $tool->setVersion('v3.0.0-rc.2');
+    $this->assertTrue($tool->needsAuth());
+  }
+
   public function testParseLandoList() {
     $tool = new MockLandoTool();
     $text = $this->makeRandomString();

--- a/tests/Tool/LandoToolTest.php
+++ b/tests/Tool/LandoToolTest.php
@@ -75,6 +75,7 @@ final class LandoToolTest extends TestCase {
     $valkey = (object) [$val => $key];
 
     # Make sure we can skip over version complaints and other preamble text.
+    $tool->setVersion('v3.0.0-beta.36');
     $lines = [
       $text,
       '',
@@ -84,7 +85,20 @@ final class LandoToolTest extends TestCase {
     ];
     $this->assertEquals($keyval, $tool->parseLandoList($lines)[0]);
 
-    # Make sure we can parse output from lando 3.0.0 >= beta.37
+    # Make sure we can parse output from lando 3.0.0 <= beta.36
+    $lines = [
+      '{',
+      '"' . $key . '": "' . $val .'"',
+      '}',
+      '{',
+      '"' . $val . '": "' . $key .'"',
+      '}',
+    ];
+    $this->assertEquals($keyval, $tool->parseLandoList($lines)[0]);
+    $this->assertEquals($valkey, $tool->parseLandoList($lines)[1]);
+
+    # Make sure we can parse output from 3.0.0-beta.37 to 3.0.0-rc.1
+    $tool->setVersion('v3.0.0-beta.48');
     $lines = [
       '[',
       '{',
@@ -98,17 +112,24 @@ final class LandoToolTest extends TestCase {
     $this->assertEquals($keyval, $tool->parseLandoList($lines)[0]);
     $this->assertEquals($valkey, $tool->parseLandoList($lines)[1]);
 
-    # Make sure we can parse output from lando 3.0.0 <= beta.36
+    # Make sure we can parse output from 3.0.0 >= rc.2
+    $tool->setVersion('v3.0.0-rc.9');
     $lines = [
       '{',
-      '"' . $key . '": "' . $val .'"',
-      '}',
+      $text . ': [',
       '{',
-      '"' . $val . '": "' . $key .'"',
+      $key . ": '" . $val . "'",
+      '},',
+      '{',
+      $val . ": '" . $key . "'",
+      '}',
+      ']',
       '}',
     ];
-    $this->assertEquals($keyval, $tool->parseLandoList($lines)[0]);
-    $this->assertEquals($valkey, $tool->parseLandoList($lines)[1]);
+    $this->assertEquals($text, $tool->parseLandoList($lines)[0]->name);
+    $this->assertTrue($tool->parseLandoList($lines)[0]->running);
+    $this->assertEquals($keyval, $tool->parseLandoList($lines)[0]->info[0]);
+    $this->assertEquals($valkey, $tool->parseLandoList($lines)[0]->info[1]);
   }
 
   /**
@@ -123,12 +144,41 @@ final class LandoToolTest extends TestCase {
     $tool->enable();
     $tool->messages = [];
 
-    # Make sure the tool is ready, then call the method.
+    # Make sure the tool is ready.
     $this->assertTrue($tool->isEnabled());
-    $tool->requireStarted();
 
-    # Make sure it executed the things and the status is now running.
+    # First test should fail: can’t determine version.
+    $tool->requireStarted();
     $expect = [
+      [LogLevel::NOTICE, '{mockLando} $ {%command}', ['%command' => "$echo version"]],
+      [LogLevel::ERROR,  '{mockLando} Unable to determine version', []],
+    ];
+    $this->verifyMessages($expect, $tool->messages, TRUE);
+    $this->assertFalse($tool->isEnabled());
+    $tool->enable();
+    $tool->messages = [];
+
+    # Second test should succeed with warning because version is weird.
+    $tool->requireStarted();
+    $expect = [
+      [LogLevel::NOTICE,  '{mockLando} $ {%command}', ['%command' => "$echo version"]],
+      [LogLevel::WARNING, '{mockLando} Unrecognized Lando version %v; some functions may not work.', ['%v' => $tool->getVersion()]],
+      [LogLevel::NOTICE,  '{mockLando} $ {%command}', ['%command' => "$echo list"]],
+      [LogLevel::WARNING, '{mockLando} Unable to determine status for Lando environment "{%name}"', ['%name' => $project]],
+      [LogLevel::NOTICE,  '{mockLando} $ {%command}', ['%command' => "$echo start"]],
+      [LogLevel::NOTICE,  '{mockLando} $ {%command}', ['%command' => "$echo list"]],
+    ];
+    $this->verifyMessages($expect, $tool->messages, TRUE);
+    $this->assertTrue($tool->getStatus()->running);
+    $tool->setStatus(NULL);
+    $tool->setVersion(NULL);
+    $tool->messages = [];
+
+    # Third test should succeed without warning.
+    # Make sure it executed the things and the status is now running.
+    $tool->requireStarted();
+    $expect = [
+      [LogLevel::NOTICE, '{mockLando} $ {%command}', ['%command' => "$echo version"]],
       [LogLevel::NOTICE, '{mockLando} $ {%command}', ['%command' => "$echo list"]],
       [LogLevel::NOTICE, '{mockLando} $ {%command}', ['%command' => "$echo start"]],
       [LogLevel::NOTICE, '{mockLando} $ {%command}', ['%command' => "$echo list"]],
@@ -157,11 +207,22 @@ final class LandoToolTest extends TestCase {
     $echo = $tool->getExecutable();
     $tool->messages = [];
 
+    # Make sure it fails if it can’t find this project’s name.
+    do {
+      $unknown = $this->makeRandomString();
+    } while ($unknown == $project);
+    $tool->updateStatus($unknown);
+    $expect = [
+      [LogLevel::NOTICE,  '{mockLando} $ {%command}', ['%command' => "$echo list"]],
+      [LogLevel::WARNING, '{mockLando} Unable to determine status for Lando environment "{%name}"', ['%name' => $unknown]],
+    ];
+    $this->verifyMessages($expect, $tool->messages, TRUE);
+    $tool->messages = [];
+
     # Make sure it fails if the tool is disabled.
     $this->assertFalse($tool->isEnabled());
     $tool->updateStatus();
     $expect = [
-      [LogLevel::NOTICE,  '{mockLando} $ {%command}', ['%command' => "$echo list"]],
       [LogLevel::WARNING, '{mockLando} No Lando environment configured or specified', []],
     ];
     $this->verifyMessages($expect, $tool->messages, TRUE);
@@ -176,16 +237,5 @@ final class LandoToolTest extends TestCase {
     ];
     $this->verifyMessages($expect, $tool->messages, TRUE);
     $tool->messages = [];
-
-    # Make sure it fails if it can’t find this project’s name.
-    do {
-      $unknown = $this->makeRandomString();
-    } while ($unknown == $project);
-    $tool->updateStatus($unknown);
-    $expect = [
-      [LogLevel::NOTICE,  '{mockLando} $ {%command}', ['%command' => "$echo list"]],
-      [LogLevel::WARNING, '{mockLando} Unable to determine status for Lando environment "{%name}"', ['%name' => $unknown]],
-    ];
-    $this->verifyMessages($expect, $tool->messages, TRUE);
   }
 }

--- a/tests/coverage.xml
+++ b/tests/coverage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1550354790">
-  <project timestamp="1550354790">
+<coverage generated="1550359043">
+  <project timestamp="1550359043">
     <package name="MountHolyoke\Jorge\Command">
       <file name="/Users/jproctor/Projects/jorge/src/Command/DrushCommand.php">
         <class name="MountHolyoke\Jorge\Command\DrushCommand" namespace="MountHolyoke\Jorge\Command">
@@ -74,11 +74,12 @@
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Command/ResetCommand.php">
         <class name="MountHolyoke\Jorge\Command\ResetCommand" namespace="MountHolyoke\Jorge\Command">
-          <metrics complexity="31" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="110" coveredelements="110"/>
+          <metrics complexity="35" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="115" coveredstatements="115" elements="121" coveredelements="121"/>
         </class>
         <line num="37" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="24"/>
         <line num="39" type="stmt" count="24"/>
         <line num="40" type="stmt" count="24"/>
+        <line num="41" type="stmt" count="24"/>
         <line num="42" type="stmt" count="24"/>
         <line num="43" type="stmt" count="24"/>
         <line num="44" type="stmt" count="24"/>
@@ -132,7 +133,7 @@
         <line num="148" type="stmt" count="1"/>
         <line num="150" type="stmt" count="1"/>
         <line num="152" type="stmt" count="1"/>
-        <line num="165" type="method" name="executeDrupal7" visibility="protected" complexity="6" crap="6" count="1"/>
+        <line num="165" type="method" name="executeDrupal7" visibility="protected" complexity="8" crap="8" count="1"/>
         <line num="166" type="stmt" count="1"/>
         <line num="167" type="stmt" count="1"/>
         <line num="170" type="stmt" count="1"/>
@@ -145,6 +146,11 @@
         <line num="178" type="stmt" count="1"/>
         <line num="179" type="stmt" count="1"/>
         <line num="180" type="stmt" count="1"/>
+        <line num="182" type="stmt" count="1"/>
+        <line num="183" type="stmt" count="1"/>
+        <line num="184" type="stmt" count="1"/>
+        <line num="185" type="stmt" count="1"/>
+        <line num="187" type="stmt" count="1"/>
         <line num="189" type="stmt" count="1"/>
         <line num="191" type="stmt" count="1"/>
         <line num="192" type="stmt" count="1"/>
@@ -158,7 +164,7 @@
         <line num="205" type="stmt" count="1"/>
         <line num="206" type="stmt" count="1"/>
         <line num="208" type="stmt" count="1"/>
-        <line num="219" type="method" name="executeDrupal8" visibility="protected" complexity="6" crap="6" count="1"/>
+        <line num="219" type="method" name="executeDrupal8" visibility="protected" complexity="8" crap="8" count="1"/>
         <line num="220" type="stmt" count="1"/>
         <line num="221" type="stmt" count="1"/>
         <line num="222" type="stmt" count="1"/>
@@ -173,6 +179,11 @@
         <line num="234" type="stmt" count="1"/>
         <line num="235" type="stmt" count="1"/>
         <line num="236" type="stmt" count="1"/>
+        <line num="238" type="stmt" count="1"/>
+        <line num="239" type="stmt" count="1"/>
+        <line num="240" type="stmt" count="1"/>
+        <line num="241" type="stmt" count="1"/>
+        <line num="243" type="stmt" count="1"/>
         <line num="245" type="stmt" count="1"/>
         <line num="248" type="stmt" count="1"/>
         <line num="252" type="stmt" count="1"/>
@@ -186,7 +197,7 @@
         <line num="265" type="stmt" count="1"/>
         <line num="266" type="stmt" count="1"/>
         <line num="268" type="stmt" count="1"/>
-        <metrics loc="269" ncloc="161" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="110" coveredelements="110"/>
+        <metrics loc="269" ncloc="193" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="115" coveredstatements="115" elements="121" coveredelements="121"/>
       </file>
     </package>
     <package name="MountHolyoke\Jorge\Helper">
@@ -475,7 +486,7 @@
         <line num="68" type="stmt" count="18"/>
         <line num="69" type="stmt" count="18"/>
         <line num="71" type="stmt" count="18"/>
-        <line num="81" type="method" name="needsAuth" visibility="protected" complexity="3" crap="3" count="1"/>
+        <line num="81" type="method" name="needsAuth" visibility="public" complexity="3" crap="3" count="1"/>
         <line num="82" type="stmt" count="1"/>
         <line num="83" type="stmt" count="1"/>
         <line num="84" type="stmt" count="1"/>
@@ -665,6 +676,6 @@
         <metrics loc="320" ncloc="191" classes="1" methods="20" coveredmethods="19" conditionals="0" coveredconditionals="0" statements="84" coveredstatements="76" elements="104" coveredelements="95"/>
       </file>
     </package>
-    <metrics files="10" loc="1641" ncloc="1045" classes="10" methods="66" coveredmethods="65" conditionals="0" coveredconditionals="0" statements="530" coveredstatements="522" elements="596" coveredelements="587"/>
+    <metrics files="10" loc="1641" ncloc="1077" classes="10" methods="66" coveredmethods="65" conditionals="0" coveredconditionals="0" statements="541" coveredstatements="533" elements="607" coveredelements="598"/>
   </project>
 </coverage>

--- a/tests/coverage.xml
+++ b/tests/coverage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1550352908">
-  <project timestamp="1550352908">
+<coverage generated="1550354790">
+  <project timestamp="1550354790">
     <package name="MountHolyoke\Jorge\Command">
       <file name="/Users/jproctor/Projects/jorge/src/Command/DrushCommand.php">
         <class name="MountHolyoke\Jorge\Command\DrushCommand" namespace="MountHolyoke\Jorge\Command">
@@ -79,114 +79,114 @@
         <line num="37" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="24"/>
         <line num="39" type="stmt" count="24"/>
         <line num="40" type="stmt" count="24"/>
-        <line num="41" type="stmt" count="24"/>
         <line num="42" type="stmt" count="24"/>
         <line num="43" type="stmt" count="24"/>
         <line num="44" type="stmt" count="24"/>
         <line num="45" type="stmt" count="24"/>
         <line num="46" type="stmt" count="24"/>
         <line num="47" type="stmt" count="24"/>
-        <line num="51" type="stmt" count="24"/>
-        <line num="58" type="stmt" count="24"/>
-        <line num="68" type="method" name="initialize" visibility="protected" complexity="10" crap="10" count="3"/>
-        <line num="69" type="stmt" count="3"/>
-        <line num="70" type="stmt" count="3"/>
+        <line num="48" type="stmt" count="24"/>
+        <line num="52" type="stmt" count="24"/>
+        <line num="60" type="stmt" count="24"/>
+        <line num="70" type="method" name="initialize" visibility="protected" complexity="10" crap="10" count="3"/>
         <line num="71" type="stmt" count="3"/>
         <line num="72" type="stmt" count="3"/>
         <line num="73" type="stmt" count="3"/>
-        <line num="74" type="stmt" count="2"/>
-        <line num="76" type="stmt" count="3"/>
-        <line num="77" type="stmt" count="3"/>
-        <line num="83" type="stmt" count="3"/>
-        <line num="84" type="stmt" count="3"/>
+        <line num="74" type="stmt" count="3"/>
+        <line num="75" type="stmt" count="3"/>
+        <line num="76" type="stmt" count="2"/>
+        <line num="78" type="stmt" count="3"/>
+        <line num="79" type="stmt" count="3"/>
         <line num="85" type="stmt" count="3"/>
-        <line num="86" type="stmt" count="1"/>
-        <line num="87" type="stmt" count="1"/>
-        <line num="89" type="stmt" count="3"/>
-        <line num="90" type="stmt" count="1"/>
-        <line num="93" type="stmt" count="3"/>
-        <line num="94" type="stmt" count="3"/>
+        <line num="86" type="stmt" count="3"/>
+        <line num="87" type="stmt" count="3"/>
+        <line num="88" type="stmt" count="1"/>
+        <line num="89" type="stmt" count="1"/>
+        <line num="91" type="stmt" count="3"/>
+        <line num="92" type="stmt" count="1"/>
         <line num="95" type="stmt" count="3"/>
+        <line num="96" type="stmt" count="3"/>
         <line num="97" type="stmt" count="3"/>
-        <line num="108" type="method" name="interact" visibility="protected" complexity="3" crap="3" count="1"/>
-        <line num="109" type="stmt" count="1"/>
-        <line num="110" type="stmt" count="1"/>
+        <line num="99" type="stmt" count="3"/>
+        <line num="110" type="method" name="interact" visibility="protected" complexity="3" crap="3" count="1"/>
         <line num="111" type="stmt" count="1"/>
-        <line num="114" type="stmt" count="1"/>
+        <line num="112" type="stmt" count="1"/>
+        <line num="113" type="stmt" count="1"/>
         <line num="116" type="stmt" count="1"/>
-        <line num="127" type="method" name="execute" visibility="protected" complexity="5" crap="5" count="3"/>
-        <line num="128" type="stmt" count="3"/>
-        <line num="129" type="stmt" count="3"/>
-        <line num="130" type="stmt" count="1"/>
-        <line num="132" type="stmt" count="2"/>
-        <line num="133" type="stmt" count="1"/>
+        <line num="118" type="stmt" count="1"/>
+        <line num="129" type="method" name="execute" visibility="protected" complexity="5" crap="5" count="3"/>
+        <line num="130" type="stmt" count="3"/>
+        <line num="131" type="stmt" count="3"/>
+        <line num="132" type="stmt" count="1"/>
+        <line num="134" type="stmt" count="2"/>
         <line num="135" type="stmt" count="1"/>
         <line num="137" type="stmt" count="1"/>
-        <line num="138" type="stmt" count="1"/>
         <line num="139" type="stmt" count="1"/>
         <line num="140" type="stmt" count="1"/>
         <line num="141" type="stmt" count="1"/>
+        <line num="142" type="stmt" count="1"/>
         <line num="143" type="stmt" count="1"/>
-        <line num="144" type="stmt" count="1"/>
         <line num="145" type="stmt" count="1"/>
         <line num="146" type="stmt" count="1"/>
+        <line num="147" type="stmt" count="1"/>
         <line num="148" type="stmt" count="1"/>
         <line num="150" type="stmt" count="1"/>
-        <line num="163" type="method" name="executeDrupal7" visibility="protected" complexity="6" crap="6" count="1"/>
-        <line num="164" type="stmt" count="1"/>
-        <line num="165" type="stmt" count="1"/>
-        <line num="168" type="stmt" count="1"/>
-        <line num="169" type="stmt" count="1"/>
+        <line num="152" type="stmt" count="1"/>
+        <line num="165" type="method" name="executeDrupal7" visibility="protected" complexity="6" crap="6" count="1"/>
+        <line num="166" type="stmt" count="1"/>
+        <line num="167" type="stmt" count="1"/>
         <line num="170" type="stmt" count="1"/>
         <line num="171" type="stmt" count="1"/>
+        <line num="172" type="stmt" count="1"/>
         <line num="173" type="stmt" count="1"/>
-        <line num="174" type="stmt" count="1"/>
         <line num="175" type="stmt" count="1"/>
         <line num="176" type="stmt" count="1"/>
         <line num="177" type="stmt" count="1"/>
         <line num="178" type="stmt" count="1"/>
+        <line num="179" type="stmt" count="1"/>
         <line num="180" type="stmt" count="1"/>
-        <line num="182" type="stmt" count="1"/>
-        <line num="183" type="stmt" count="1"/>
-        <line num="184" type="stmt" count="1"/>
-        <line num="186" type="stmt" count="1"/>
-        <line num="187" type="stmt" count="1"/>
-        <line num="188" type="stmt" count="1"/>
+        <line num="189" type="stmt" count="1"/>
         <line num="191" type="stmt" count="1"/>
-        <line num="194" type="stmt" count="1"/>
+        <line num="192" type="stmt" count="1"/>
+        <line num="193" type="stmt" count="1"/>
         <line num="195" type="stmt" count="1"/>
         <line num="196" type="stmt" count="1"/>
         <line num="197" type="stmt" count="1"/>
-        <line num="199" type="stmt" count="1"/>
-        <line num="210" type="method" name="executeDrupal8" visibility="protected" complexity="6" crap="6" count="1"/>
-        <line num="211" type="stmt" count="1"/>
-        <line num="212" type="stmt" count="1"/>
-        <line num="213" type="stmt" count="1"/>
-        <line num="216" type="stmt" count="1"/>
-        <line num="217" type="stmt" count="1"/>
-        <line num="218" type="stmt" count="1"/>
-        <line num="219" type="stmt" count="1"/>
+        <line num="200" type="stmt" count="1"/>
+        <line num="203" type="stmt" count="1"/>
+        <line num="204" type="stmt" count="1"/>
+        <line num="205" type="stmt" count="1"/>
+        <line num="206" type="stmt" count="1"/>
+        <line num="208" type="stmt" count="1"/>
+        <line num="219" type="method" name="executeDrupal8" visibility="protected" complexity="6" crap="6" count="1"/>
+        <line num="220" type="stmt" count="1"/>
         <line num="221" type="stmt" count="1"/>
         <line num="222" type="stmt" count="1"/>
-        <line num="223" type="stmt" count="1"/>
-        <line num="224" type="stmt" count="1"/>
         <line num="225" type="stmt" count="1"/>
         <line num="226" type="stmt" count="1"/>
         <line num="227" type="stmt" count="1"/>
-        <line num="229" type="stmt" count="1"/>
+        <line num="228" type="stmt" count="1"/>
+        <line num="230" type="stmt" count="1"/>
+        <line num="231" type="stmt" count="1"/>
         <line num="232" type="stmt" count="1"/>
+        <line num="233" type="stmt" count="1"/>
+        <line num="234" type="stmt" count="1"/>
+        <line num="235" type="stmt" count="1"/>
         <line num="236" type="stmt" count="1"/>
-        <line num="237" type="stmt" count="1"/>
-        <line num="239" type="stmt" count="1"/>
-        <line num="240" type="stmt" count="1"/>
-        <line num="241" type="stmt" count="1"/>
         <line num="245" type="stmt" count="1"/>
-        <line num="247" type="stmt" count="1"/>
         <line num="248" type="stmt" count="1"/>
-        <line num="249" type="stmt" count="1"/>
-        <line num="250" type="stmt" count="1"/>
         <line num="252" type="stmt" count="1"/>
-        <metrics loc="253" ncloc="177" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="110" coveredelements="110"/>
+        <line num="253" type="stmt" count="1"/>
+        <line num="255" type="stmt" count="1"/>
+        <line num="256" type="stmt" count="1"/>
+        <line num="257" type="stmt" count="1"/>
+        <line num="261" type="stmt" count="1"/>
+        <line num="263" type="stmt" count="1"/>
+        <line num="264" type="stmt" count="1"/>
+        <line num="265" type="stmt" count="1"/>
+        <line num="266" type="stmt" count="1"/>
+        <line num="268" type="stmt" count="1"/>
+        <metrics loc="269" ncloc="161" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="104" coveredstatements="104" elements="110" coveredelements="110"/>
       </file>
     </package>
     <package name="MountHolyoke\Jorge\Helper">
@@ -453,7 +453,7 @@
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Tool/LandoTool.php">
         <class name="MountHolyoke\Jorge\Tool\LandoTool" namespace="MountHolyoke\Jorge\Tool">
-          <metrics complexity="40" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="85" coveredstatements="85" elements="91" coveredelements="91"/>
+          <metrics complexity="43" methods="7" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="90" coveredstatements="90" elements="97" coveredelements="97"/>
         </class>
         <line num="28" type="method" name="applyVerbosity" visibility="protected" complexity="2" crap="2" count="2"/>
         <line num="30" type="stmt" count="2"/>
@@ -475,90 +475,96 @@
         <line num="68" type="stmt" count="18"/>
         <line num="69" type="stmt" count="18"/>
         <line num="71" type="stmt" count="18"/>
-        <line num="79" type="method" name="parseLandoList" visibility="protected" complexity="19" crap="19" count="3"/>
-        <line num="81" type="stmt" count="3"/>
-        <line num="82" type="stmt" count="2"/>
-        <line num="85" type="stmt" count="3"/>
-        <line num="87" type="stmt" count="1"/>
-        <line num="92" type="stmt" count="3"/>
-        <line num="93" type="stmt" count="3"/>
-        <line num="94" type="stmt" count="2"/>
-        <line num="95" type="stmt" count="2"/>
-        <line num="96" type="stmt" count="2"/>
-        <line num="98" type="stmt" count="2"/>
-        <line num="100" type="stmt" count="2"/>
-        <line num="101" type="stmt" count="1"/>
-        <line num="104" type="stmt" count="2"/>
-        <line num="105" type="stmt" count="1"/>
+        <line num="81" type="method" name="needsAuth" visibility="protected" complexity="3" crap="3" count="1"/>
+        <line num="82" type="stmt" count="1"/>
+        <line num="83" type="stmt" count="1"/>
+        <line num="84" type="stmt" count="1"/>
+        <line num="85" type="stmt" count="1"/>
+        <line num="88" type="stmt" count="1"/>
+        <line num="99" type="method" name="parseLandoList" visibility="protected" complexity="19" crap="19" count="3"/>
+        <line num="101" type="stmt" count="3"/>
+        <line num="102" type="stmt" count="2"/>
+        <line num="105" type="stmt" count="3"/>
         <line num="107" type="stmt" count="1"/>
-        <line num="116" type="stmt" count="3"/>
-        <line num="118" type="stmt" count="3"/>
-        <line num="119" type="stmt" count="2"/>
-        <line num="120" type="stmt" count="3"/>
+        <line num="112" type="stmt" count="3"/>
+        <line num="113" type="stmt" count="3"/>
+        <line num="114" type="stmt" count="2"/>
+        <line num="115" type="stmt" count="2"/>
+        <line num="116" type="stmt" count="2"/>
+        <line num="118" type="stmt" count="2"/>
+        <line num="120" type="stmt" count="2"/>
         <line num="121" type="stmt" count="1"/>
-        <line num="123" type="stmt" count="3"/>
-        <line num="125" type="stmt" count="3"/>
-        <line num="126" type="stmt" count="3"/>
-        <line num="127" type="stmt" count="3"/>
-        <line num="128" type="stmt" count="3"/>
-        <line num="129" type="stmt" count="3"/>
-        <line num="131" type="stmt" count="3"/>
-        <line num="134" type="stmt" count="3"/>
-        <line num="140" type="method" name="requireStarted" visibility="public" complexity="7" crap="7" count="1"/>
-        <line num="142" type="stmt" count="1"/>
-        <line num="143" type="stmt" count="1"/>
-        <line num="144" type="stmt" count="1"/>
-        <line num="145" type="stmt" count="1"/>
-        <line num="146" type="stmt" count="1"/>
-        <line num="147" type="stmt" count="1"/>
-        <line num="149" type="stmt" count="1"/>
-        <line num="150" type="stmt" count="1"/>
-        <line num="151" type="stmt" count="1"/>
-        <line num="152" type="stmt" count="1"/>
-        <line num="153" type="stmt" count="1"/>
-        <line num="154" type="stmt" count="1"/>
-        <line num="158" type="stmt" count="1"/>
-        <line num="159" type="stmt" count="1"/>
-        <line num="160" type="stmt" count="1"/>
-        <line num="161" type="stmt" count="1"/>
+        <line num="124" type="stmt" count="2"/>
+        <line num="125" type="stmt" count="1"/>
+        <line num="127" type="stmt" count="1"/>
+        <line num="136" type="stmt" count="3"/>
+        <line num="138" type="stmt" count="3"/>
+        <line num="139" type="stmt" count="2"/>
+        <line num="140" type="stmt" count="3"/>
+        <line num="141" type="stmt" count="1"/>
+        <line num="143" type="stmt" count="3"/>
+        <line num="145" type="stmt" count="3"/>
+        <line num="146" type="stmt" count="3"/>
+        <line num="147" type="stmt" count="3"/>
+        <line num="148" type="stmt" count="3"/>
+        <line num="149" type="stmt" count="3"/>
+        <line num="151" type="stmt" count="3"/>
+        <line num="154" type="stmt" count="3"/>
+        <line num="160" type="method" name="requireStarted" visibility="public" complexity="7" crap="7" count="1"/>
+        <line num="162" type="stmt" count="1"/>
         <line num="163" type="stmt" count="1"/>
-        <line num="173" type="method" name="updateStatus" visibility="public" complexity="7" crap="7" count="2"/>
-        <line num="174" type="stmt" count="2"/>
-        <line num="175" type="stmt" count="2"/>
-        <line num="176" type="stmt" count="2"/>
+        <line num="164" type="stmt" count="1"/>
+        <line num="165" type="stmt" count="1"/>
+        <line num="166" type="stmt" count="1"/>
+        <line num="167" type="stmt" count="1"/>
+        <line num="169" type="stmt" count="1"/>
+        <line num="170" type="stmt" count="1"/>
+        <line num="171" type="stmt" count="1"/>
+        <line num="172" type="stmt" count="1"/>
+        <line num="173" type="stmt" count="1"/>
+        <line num="174" type="stmt" count="1"/>
         <line num="178" type="stmt" count="1"/>
         <line num="179" type="stmt" count="1"/>
         <line num="180" type="stmt" count="1"/>
-        <line num="182" type="stmt" count="1"/>
-        <line num="185" type="stmt" count="2"/>
-        <line num="186" type="stmt" count="2"/>
-        <line num="187" type="stmt" count="1"/>
-        <line num="188" type="stmt" count="1"/>
-        <line num="191" type="stmt" count="2"/>
-        <line num="192" type="stmt" count="2"/>
-        <line num="193" type="stmt" count="2"/>
+        <line num="181" type="stmt" count="1"/>
+        <line num="183" type="stmt" count="1"/>
+        <line num="193" type="method" name="updateStatus" visibility="public" complexity="7" crap="7" count="2"/>
         <line num="194" type="stmt" count="2"/>
-        <line num="195" type="stmt" count="1"/>
+        <line num="195" type="stmt" count="2"/>
         <line num="196" type="stmt" count="2"/>
-        <line num="199" type="stmt" count="2"/>
-        <line num="200" type="stmt" count="2"/>
-        <line num="201" type="stmt" count="2"/>
-        <line num="202" type="stmt" count="2"/>
-        <line num="203" type="stmt" count="2"/>
+        <line num="198" type="stmt" count="1"/>
+        <line num="199" type="stmt" count="1"/>
+        <line num="200" type="stmt" count="1"/>
+        <line num="202" type="stmt" count="1"/>
+        <line num="205" type="stmt" count="2"/>
         <line num="206" type="stmt" count="2"/>
-        <metrics loc="207" ncloc="145" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="85" coveredstatements="85" elements="91" coveredelements="91"/>
+        <line num="207" type="stmt" count="1"/>
+        <line num="208" type="stmt" count="1"/>
+        <line num="211" type="stmt" count="2"/>
+        <line num="212" type="stmt" count="2"/>
+        <line num="213" type="stmt" count="2"/>
+        <line num="214" type="stmt" count="2"/>
+        <line num="215" type="stmt" count="1"/>
+        <line num="216" type="stmt" count="2"/>
+        <line num="219" type="stmt" count="2"/>
+        <line num="220" type="stmt" count="2"/>
+        <line num="221" type="stmt" count="2"/>
+        <line num="222" type="stmt" count="2"/>
+        <line num="223" type="stmt" count="2"/>
+        <line num="226" type="stmt" count="2"/>
+        <metrics loc="227" ncloc="155" classes="1" methods="7" coveredmethods="7" conditionals="0" coveredconditionals="0" statements="90" coveredstatements="90" elements="97" coveredelements="97"/>
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Tool/Tool.php">
         <class name="MountHolyoke\Jorge\Tool\Tool" namespace="MountHolyoke\Jorge\Tool">
           <metrics complexity="38" methods="20" coveredmethods="19" conditionals="0" coveredconditionals="0" statements="84" coveredstatements="76" elements="104" coveredelements="95"/>
         </class>
-        <line num="56" type="method" name="__construct" visibility="public" complexity="3" crap="3" count="46"/>
-        <line num="57" type="stmt" count="46"/>
+        <line num="56" type="method" name="__construct" visibility="public" complexity="3" crap="3" count="47"/>
+        <line num="57" type="stmt" count="47"/>
         <line num="58" type="stmt" count="10"/>
-        <line num="60" type="stmt" count="46"/>
-        <line num="61" type="stmt" count="46"/>
+        <line num="60" type="stmt" count="47"/>
+        <line num="61" type="stmt" count="47"/>
         <line num="62" type="stmt" count="1"/>
-        <line num="64" type="stmt" count="46"/>
+        <line num="64" type="stmt" count="47"/>
         <line num="72" type="method" name="applyVerbosity" visibility="protected" complexity="1" crap="1" count="3"/>
         <line num="73" type="stmt" count="3"/>
         <line num="81" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="10"/>
@@ -601,8 +607,8 @@
         <line num="157" type="stmt" count="1"/>
         <line num="163" type="method" name="getExecutable" visibility="public" complexity="1" crap="1" count="28"/>
         <line num="164" type="stmt" count="28"/>
-        <line num="170" type="method" name="getName" visibility="public" complexity="1" crap="1" count="46"/>
-        <line num="171" type="stmt" count="46"/>
+        <line num="170" type="method" name="getName" visibility="public" complexity="1" crap="1" count="47"/>
+        <line num="171" type="stmt" count="47"/>
         <line num="179" type="method" name="getStatus" visibility="public" complexity="3" crap="3" count="9"/>
         <line num="180" type="stmt" count="9"/>
         <line num="181" type="stmt" count="2"/>
@@ -647,9 +653,9 @@
         <line num="283" type="stmt" count="4"/>
         <line num="284" type="stmt" count="4"/>
         <line num="287" type="stmt" count="29"/>
-        <line num="296" type="method" name="setName" visibility="protected" complexity="1" crap="1" count="38"/>
-        <line num="297" type="stmt" count="38"/>
-        <line num="298" type="stmt" count="38"/>
+        <line num="296" type="method" name="setName" visibility="protected" complexity="1" crap="1" count="39"/>
+        <line num="297" type="stmt" count="39"/>
+        <line num="298" type="stmt" count="39"/>
         <line num="307" type="method" name="setStatus" visibility="public" complexity="1" crap="1" count="27"/>
         <line num="308" type="stmt" count="27"/>
         <line num="309" type="stmt" count="27"/>
@@ -659,6 +665,6 @@
         <metrics loc="320" ncloc="191" classes="1" methods="20" coveredmethods="19" conditionals="0" coveredconditionals="0" statements="84" coveredstatements="76" elements="104" coveredelements="95"/>
       </file>
     </package>
-    <metrics files="10" loc="1605" ncloc="1051" classes="10" methods="65" coveredmethods="64" conditionals="0" coveredconditionals="0" statements="525" coveredstatements="517" elements="590" coveredelements="581"/>
+    <metrics files="10" loc="1641" ncloc="1045" classes="10" methods="66" coveredmethods="65" conditionals="0" coveredconditionals="0" statements="530" coveredstatements="522" elements="596" coveredelements="587"/>
   </project>
 </coverage>

--- a/tests/coverage.xml
+++ b/tests/coverage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1535410437">
-  <project timestamp="1535410437">
+<coverage generated="1550352908">
+  <project timestamp="1550352908">
     <package name="MountHolyoke\Jorge\Command">
       <file name="/Users/jproctor/Projects/jorge/src/Command/DrushCommand.php">
         <class name="MountHolyoke\Jorge\Command\DrushCommand" namespace="MountHolyoke\Jorge\Command">
@@ -453,68 +453,100 @@
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Tool/LandoTool.php">
         <class name="MountHolyoke\Jorge\Tool\LandoTool" namespace="MountHolyoke\Jorge\Tool">
-          <metrics complexity="22" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="53" coveredstatements="53" elements="59" coveredelements="59"/>
+          <metrics complexity="40" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="85" coveredstatements="85" elements="91" coveredelements="91"/>
         </class>
-        <line num="25" type="method" name="applyVerbosity" visibility="protected" complexity="2" crap="2" count="2"/>
-        <line num="27" type="stmt" count="2"/>
-        <line num="34" type="stmt" count="2"/>
-        <line num="35" type="stmt" count="2"/>
-        <line num="37" type="stmt" count="1"/>
-        <line num="43" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="22"/>
-        <line num="44" type="stmt" count="22"/>
-        <line num="45" type="stmt" count="22"/>
-        <line num="50" type="method" name="initialize" visibility="protected" complexity="4" crap="4" count="19"/>
-        <line num="51" type="stmt" count="19"/>
-        <line num="53" type="stmt" count="19"/>
-        <line num="54" type="stmt" count="1"/>
-        <line num="55" type="stmt" count="1"/>
-        <line num="58" type="stmt" count="19"/>
-        <line num="59" type="stmt" count="2"/>
-        <line num="60" type="stmt" count="2"/>
-        <line num="64" type="stmt" count="18"/>
-        <line num="65" type="stmt" count="18"/>
-        <line num="66" type="stmt" count="18"/>
+        <line num="28" type="method" name="applyVerbosity" visibility="protected" complexity="2" crap="2" count="2"/>
+        <line num="30" type="stmt" count="2"/>
+        <line num="37" type="stmt" count="2"/>
+        <line num="38" type="stmt" count="2"/>
+        <line num="40" type="stmt" count="1"/>
+        <line num="46" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="22"/>
+        <line num="47" type="stmt" count="22"/>
+        <line num="48" type="stmt" count="22"/>
+        <line num="53" type="method" name="initialize" visibility="protected" complexity="4" crap="4" count="19"/>
+        <line num="54" type="stmt" count="19"/>
+        <line num="56" type="stmt" count="19"/>
+        <line num="57" type="stmt" count="1"/>
+        <line num="58" type="stmt" count="1"/>
+        <line num="61" type="stmt" count="19"/>
+        <line num="62" type="stmt" count="2"/>
+        <line num="63" type="stmt" count="2"/>
+        <line num="67" type="stmt" count="18"/>
         <line num="68" type="stmt" count="18"/>
-        <line num="76" type="method" name="parseLandoList" visibility="protected" complexity="6" crap="6" count="3"/>
-        <line num="78" type="stmt" count="3"/>
-        <line num="79" type="stmt" count="1"/>
-        <line num="82" type="stmt" count="3"/>
-        <line num="84" type="stmt" count="1"/>
-        <line num="88" type="stmt" count="3"/>
-        <line num="89" type="stmt" count="3"/>
-        <line num="90" type="stmt" count="1"/>
+        <line num="69" type="stmt" count="18"/>
+        <line num="71" type="stmt" count="18"/>
+        <line num="79" type="method" name="parseLandoList" visibility="protected" complexity="19" crap="19" count="3"/>
+        <line num="81" type="stmt" count="3"/>
+        <line num="82" type="stmt" count="2"/>
+        <line num="85" type="stmt" count="3"/>
+        <line num="87" type="stmt" count="1"/>
+        <line num="92" type="stmt" count="3"/>
         <line num="93" type="stmt" count="3"/>
-        <line num="95" type="stmt" count="3"/>
-        <line num="101" type="method" name="requireStarted" visibility="public" complexity="2" crap="2" count="1"/>
-        <line num="102" type="stmt" count="1"/>
-        <line num="103" type="stmt" count="1"/>
-        <line num="104" type="stmt" count="1"/>
-        <line num="106" type="stmt" count="1"/>
-        <line num="116" type="method" name="updateStatus" visibility="public" complexity="7" crap="7" count="2"/>
-        <line num="117" type="stmt" count="2"/>
-        <line num="118" type="stmt" count="2"/>
-        <line num="119" type="stmt" count="1"/>
-        <line num="120" type="stmt" count="1"/>
-        <line num="122" type="stmt" count="2"/>
-        <line num="123" type="stmt" count="2"/>
-        <line num="124" type="stmt" count="2"/>
-        <line num="125" type="stmt" count="1"/>
-        <line num="127" type="stmt" count="1"/>
-        <line num="128" type="stmt" count="1"/>
-        <line num="129" type="stmt" count="1"/>
-        <line num="131" type="stmt" count="1"/>
-        <line num="134" type="stmt" count="2"/>
-        <line num="135" type="stmt" count="2"/>
-        <line num="136" type="stmt" count="2"/>
-        <line num="137" type="stmt" count="1"/>
-        <line num="138" type="stmt" count="2"/>
-        <line num="141" type="stmt" count="2"/>
+        <line num="94" type="stmt" count="2"/>
+        <line num="95" type="stmt" count="2"/>
+        <line num="96" type="stmt" count="2"/>
+        <line num="98" type="stmt" count="2"/>
+        <line num="100" type="stmt" count="2"/>
+        <line num="101" type="stmt" count="1"/>
+        <line num="104" type="stmt" count="2"/>
+        <line num="105" type="stmt" count="1"/>
+        <line num="107" type="stmt" count="1"/>
+        <line num="116" type="stmt" count="3"/>
+        <line num="118" type="stmt" count="3"/>
+        <line num="119" type="stmt" count="2"/>
+        <line num="120" type="stmt" count="3"/>
+        <line num="121" type="stmt" count="1"/>
+        <line num="123" type="stmt" count="3"/>
+        <line num="125" type="stmt" count="3"/>
+        <line num="126" type="stmt" count="3"/>
+        <line num="127" type="stmt" count="3"/>
+        <line num="128" type="stmt" count="3"/>
+        <line num="129" type="stmt" count="3"/>
+        <line num="131" type="stmt" count="3"/>
+        <line num="134" type="stmt" count="3"/>
+        <line num="140" type="method" name="requireStarted" visibility="public" complexity="7" crap="7" count="1"/>
         <line num="142" type="stmt" count="1"/>
         <line num="143" type="stmt" count="1"/>
         <line num="144" type="stmt" count="1"/>
         <line num="145" type="stmt" count="1"/>
-        <line num="148" type="stmt" count="2"/>
-        <metrics loc="149" ncloc="102" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="53" coveredstatements="53" elements="59" coveredelements="59"/>
+        <line num="146" type="stmt" count="1"/>
+        <line num="147" type="stmt" count="1"/>
+        <line num="149" type="stmt" count="1"/>
+        <line num="150" type="stmt" count="1"/>
+        <line num="151" type="stmt" count="1"/>
+        <line num="152" type="stmt" count="1"/>
+        <line num="153" type="stmt" count="1"/>
+        <line num="154" type="stmt" count="1"/>
+        <line num="158" type="stmt" count="1"/>
+        <line num="159" type="stmt" count="1"/>
+        <line num="160" type="stmt" count="1"/>
+        <line num="161" type="stmt" count="1"/>
+        <line num="163" type="stmt" count="1"/>
+        <line num="173" type="method" name="updateStatus" visibility="public" complexity="7" crap="7" count="2"/>
+        <line num="174" type="stmt" count="2"/>
+        <line num="175" type="stmt" count="2"/>
+        <line num="176" type="stmt" count="2"/>
+        <line num="178" type="stmt" count="1"/>
+        <line num="179" type="stmt" count="1"/>
+        <line num="180" type="stmt" count="1"/>
+        <line num="182" type="stmt" count="1"/>
+        <line num="185" type="stmt" count="2"/>
+        <line num="186" type="stmt" count="2"/>
+        <line num="187" type="stmt" count="1"/>
+        <line num="188" type="stmt" count="1"/>
+        <line num="191" type="stmt" count="2"/>
+        <line num="192" type="stmt" count="2"/>
+        <line num="193" type="stmt" count="2"/>
+        <line num="194" type="stmt" count="2"/>
+        <line num="195" type="stmt" count="1"/>
+        <line num="196" type="stmt" count="2"/>
+        <line num="199" type="stmt" count="2"/>
+        <line num="200" type="stmt" count="2"/>
+        <line num="201" type="stmt" count="2"/>
+        <line num="202" type="stmt" count="2"/>
+        <line num="203" type="stmt" count="2"/>
+        <line num="206" type="stmt" count="2"/>
+        <metrics loc="207" ncloc="145" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="85" coveredstatements="85" elements="91" coveredelements="91"/>
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Tool/Tool.php">
         <class name="MountHolyoke\Jorge\Tool\Tool" namespace="MountHolyoke\Jorge\Tool">
@@ -531,9 +563,9 @@
         <line num="73" type="stmt" count="3"/>
         <line num="81" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="10"/>
         <line num="82" type="stmt" count="10"/>
-        <line num="87" type="method" name="disable" visibility="protected" complexity="1" crap="1" count="20"/>
-        <line num="88" type="stmt" count="20"/>
-        <line num="89" type="stmt" count="20"/>
+        <line num="87" type="method" name="disable" visibility="protected" complexity="1" crap="1" count="21"/>
+        <line num="88" type="stmt" count="21"/>
+        <line num="89" type="stmt" count="21"/>
         <line num="94" type="method" name="enable" visibility="protected" complexity="1" crap="1" count="26"/>
         <line num="95" type="stmt" count="26"/>
         <line num="96" type="stmt" count="26"/>
@@ -627,6 +659,6 @@
         <metrics loc="320" ncloc="191" classes="1" methods="20" coveredmethods="19" conditionals="0" coveredconditionals="0" statements="84" coveredstatements="76" elements="104" coveredelements="95"/>
       </file>
     </package>
-    <metrics files="10" loc="1547" ncloc="1008" classes="10" methods="65" coveredmethods="64" conditionals="0" coveredconditionals="0" statements="493" coveredstatements="485" elements="558" coveredelements="549"/>
+    <metrics files="10" loc="1605" ncloc="1051" classes="10" methods="65" coveredmethods="64" conditionals="0" coveredconditionals="0" statements="525" coveredstatements="517" elements="590" coveredelements="581"/>
   </project>
 </coverage>


### PR DESCRIPTION
Lando [v3.0.0-rc.2](https://github.com/lando/lando/releases/tag/v3.0.0-rc.2) made several breaking changes to the interface, including a different format for the output of `lando list` (which Jorge uses to make sure the containers are running, and which [may change](https://github.com/lando/lando/pull/1457) again) and requiring explicit authentication for `lando pull`. 

This branch addresses those changes somewhat naïvely, as opposed to addressing the bigger questions of refactoring Lando to be a different kind of thing.

Before merging, I want to make sure it still works for rc.1 and earlier.
