### PR TITLE
SSH key passphrase

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1556,16 +1556,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.0.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
-                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
                 "shasum": ""
             },
             "require": {
@@ -1577,7 +1577,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -1601,7 +1601,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2018-02-01T13:07:23+00:00"
+            "time": "2019-02-20T10:12:59+00:00"
         },
         {
             "name": "phpunit/php-token-stream",

--- a/composer.lock
+++ b/composer.lock
@@ -517,16 +517,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.2.3",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4"
+                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
-                "reference": "1f0ad51dfde4da8a6070f06adc58b4e37cbb37a4",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9dc2299a016497f9ee620be94524e6c0af0280a9",
+                "reference": "9dc2299a016497f9ee620be94524e6c0af0280a9",
                 "shasum": ""
             },
             "require": {
@@ -585,7 +585,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-25T14:35:16+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         },
         {
             "name": "symfony/contracts",
@@ -657,16 +657,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v4.2.3",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "7c16ebc2629827d4ec915a52ac809768d060a4ee"
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7c16ebc2629827d4ec915a52ac809768d060a4ee",
-                "reference": "7c16ebc2629827d4ec915a52ac809768d060a4ee",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e16b9e471703b2c60b95f14d31c1239f68f11601",
+                "reference": "e16b9e471703b2c60b95f14d31c1239f68f11601",
                 "shasum": ""
             },
             "require": {
@@ -703,20 +703,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T20:35:37+00:00"
+            "time": "2019-02-07T11:40:08+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.2.3",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "ef71816cbb264988bb57fe6a73f610888b9aa70c"
+                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/ef71816cbb264988bb57fe6a73f610888b9aa70c",
-                "reference": "ef71816cbb264988bb57fe6a73f610888b9aa70c",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/267b7002c1b70ea80db0833c3afe05f0fbde580a",
+                "reference": "267b7002c1b70ea80db0833c3afe05f0fbde580a",
                 "shasum": ""
             },
             "require": {
@@ -752,7 +752,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T20:35:37+00:00"
+            "time": "2019-02-23T15:42:05+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -873,7 +873,7 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.2.3",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
@@ -922,16 +922,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.2.3",
+            "version": "v4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0"
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/d461670ee145092b7e2a56c1da7118f19cadadb0",
-                "reference": "d461670ee145092b7e2a56c1da7118f19cadadb0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/761fa560a937fd7686e5274ff89dcfa87a5047df",
+                "reference": "761fa560a937fd7686e5274ff89dcfa87a5047df",
                 "shasum": ""
             },
             "require": {
@@ -977,7 +977,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-01-16T20:35:37+00:00"
+            "time": "2019-02-23T15:17:42+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -161,8 +161,5 @@ only apply to Drush, you can escape -v/--verbose as above.
       }
       $this->drush_command = implode(' ', $arguments);
     }
-    if ($this->verbosity > OutputInterface::VERBOSITY_NORMAL) {
-      $this->drush_command = trim($this->drush_command . ' --verbose');
-    }
   }
 }

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -231,7 +231,14 @@ class ResetCommand extends Command {
     $git->run(['pull']);
     $composer->run(['command' => 'install']);
     $lando->requireStarted();
-    $lando_pull = 'ssh-agent-pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
+    $lando_tooling = $lando->getConfig('tooling');
+    if (!empty($lando_tooling) && array_key_exists('ssh-agent-pull', $lando_tooling)) {
+      $lando->writeln('If you use an ssh key passphrase, you may need to enter it now.');
+      $lando_pull = 'ssh-agent-pull';
+    } else {
+      $lando_pull = 'pull';
+    }
+    $lando_pull .= ' --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
     if ($this->params['rsync']) {
       $lando_pull .= ' --rsync';
     }
@@ -242,7 +249,6 @@ class ResetCommand extends Command {
       }
       $lando_pull .= ' --auth=' . $this->params['auth'];
     }
-    $this->jorge->getOutput()->writeln('If you use an ssh key passphrase, enter it now.');
     $lando->run($lando_pull);
 
     $drushSequence = [

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -231,7 +231,7 @@ class ResetCommand extends Command {
     $git->run(['pull']);
     $composer->run(['command' => 'install']);
     $lando->requireStarted();
-    $lando_pull = 'pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
+    $lando_pull = 'ssh-agent-pull --code=none --database=' . $this->params['database'] . ' --files=' . $this->params['files'];
     if ($this->params['rsync']) {
       $lando_pull .= ' --rsync';
     }
@@ -242,6 +242,7 @@ class ResetCommand extends Command {
       }
       $lando_pull .= ' --auth=' . $this->params['auth'];
     }
+    $this->jorge->getOutput()->writeln('If you use an ssh key passphrase, enter it now.');
     $lando->run($lando_pull);
 
     $drushSequence = [

--- a/src/Tool/LandoTool.php
+++ b/src/Tool/LandoTool.php
@@ -29,9 +29,9 @@ class LandoTool extends Tool {
     $verbosityMap = [
       OutputInterface::VERBOSITY_QUIET        => '2>&1',
       OutputInterface::VERBOSITY_NORMAL       => '',
-      OutputInterface::VERBOSITY_VERBOSE      => '-- -v',
-      OutputInterface::VERBOSITY_VERY_VERBOSE => '-- -vv',
-      OutputInterface::VERBOSITY_DEBUG        => '-- -vvvv',
+      OutputInterface::VERBOSITY_VERBOSE      => '-v',
+      OutputInterface::VERBOSITY_VERY_VERBOSE => '-vv',
+      OutputInterface::VERBOSITY_DEBUG        => '-vvvv',
     ];
 
     if (array_key_exists($this->verbosity, $verbosityMap)) {

--- a/tests/Command/DrushCommandTest.php
+++ b/tests/Command/DrushCommandTest.php
@@ -154,11 +154,5 @@ final class DrushCommandTest extends TestCase {
     $input = new ArrayInput(['drush_command' => [$dc], '--no-interaction' => TRUE]);
     $command->initialize($input, $output);
     $this->assertSame("$dc --no", $command->getDrushCommand());
-
-    $dc = $this->makeRandomString();
-    $input = new ArrayInput(['drush_command' => [$dc]]);
-    $output->setVerbosity(OutputInterface::VERBOSITY_VERBOSE);
-    $command->initialize($input, $output);
-    $this->assertSame("$dc --verbose", $command->getDrushCommand());
   }
 }

--- a/tests/JorgeDefaultTest.php
+++ b/tests/JorgeDefaultTest.php
@@ -35,8 +35,7 @@ final class JorgeDefaultTest extends TestCase {
    */
   public function testConfigure(): void {
     $defaultCommands = $this->jorge->all();
-    $defaultTools = $this->jorge->allTools();
-
+    $defaultTools = $this->jorge->allTools() ?: [];
     $this->jorge->configure();
 
     $this->assertSame('Jorge', $this->jorge->getName());

--- a/tests/Tool/LandoToolTest.php
+++ b/tests/Tool/LandoToolTest.php
@@ -24,9 +24,9 @@ final class LandoToolTest extends TestCase {
     $verbosityMap = [
       OutputInterface::VERBOSITY_QUIET        => '2>&1',
       OutputInterface::VERBOSITY_NORMAL       => '',
-      OutputInterface::VERBOSITY_VERBOSE      => '-- -v',
-      OutputInterface::VERBOSITY_VERY_VERBOSE => '-- -vv',
-      OutputInterface::VERBOSITY_DEBUG        => '-- -vvvv',
+      OutputInterface::VERBOSITY_VERBOSE      => '-v',
+      OutputInterface::VERBOSITY_VERY_VERBOSE => '-vv',
+      OutputInterface::VERBOSITY_DEBUG        => '-vvvv',
       0                                       => '',
     ];
 


### PR DESCRIPTION
This branch tweaks Jorge to (clumsily) handle the possibility that the user has an SSH key passphrase (which will be necessary multiple times for a Reset operation).

The main change is to look for the presence of `ssh-agent-pull` in tooling in the project’s Lando config, and use it instead of “regular” `pull` if it exists, along with a hard-coded prompt for the passphrase since it isn’t otherwise passed through.

The primary project we use this for will have such a script (after a PR there), adapted from Lando issue #478, to inject an `ssh-agent` into the `appserver` container so the user only needs to type the passphrase once.

**Note:** there is currently no test coverage for this! It is decidedly the wrong approach, for reasons previously discussed as well as the commentary in that issue, and hopefully will be the last change until we restructure to take advantage of [Lando’s new tooling capabilities](https://docs.devwithlando.io/config/tooling.html).

Extra bonus TODO: I also changed the handling of verbosity, because rc.13 (at least) passes arguments through to Drush very differently than rc.1 and older. This might make things weird, and probably we should do some more digging to find out when that changed and make it version-conditional as well. Assuming it survives restructuring in a recognizable form—it might become necessary to require a baseline version of Lando.