### PR TITLE
Call writeln on the correct object

### DIFF
--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -233,7 +233,7 @@ class ResetCommand extends Command {
     $lando->requireStarted();
     $lando_tooling = $lando->getConfig('tooling');
     if (!empty($lando_tooling) && array_key_exists('ssh-agent-pull', $lando_tooling)) {
-      $lando->writeln('If you use an ssh key passphrase, you may need to enter it now.');
+      $this->jorge->getOutput()->writeln('If you use an ssh key passphrase, you may need to enter it now.');
       $lando_pull = 'ssh-agent-pull';
     } else {
       $lando_pull = 'pull';


### PR DESCRIPTION

It worked in dev.

(Except it probably didn’t; I may have changed it when I rearranged lines in that last commit and didn’t test running it again, only that it passed PHPUnit, and I had already left myself a warning in PR #13 that the code wasn’t being tested. Sigh.)
