### PR TITLE
Add option for drush cim when resetting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Optionally, you may also have the key `include_config`, which specifies a list o
 A config file may include the key `reset`, which contains a block that provides any of seven optional parameters to the `reset` command (described below):
 - `auth    ` - A Terminus machine token to authenticate with Pantheon for the reset
 - `branch  ` - Which Git branch to reset your current codebase to (default is `master`)
+- `import  ` - Whether to run `drush config-import` after pulling the database (default is `FALSE`)
 - `content ` - Which Pantheon environment to copy database and files from (default is `dev`)
 - `database` - Which Pantheon environment to copy the database from (default matches `content`)
 - `files   ` - Which Pantheon environment to copy the files from (default matches `database`)
@@ -93,6 +94,8 @@ Sets up the local development environment as specified in the configuration file
 Starts Lando if it is not already running, then uses `lando pull` to fetch the site from Pantheon.
 
 Optionally takes command-line switches which will override the settings described above (except `rsync`); see `jorge help reset` for details.
+
+If you are resetting to a branch other than master (using `-b`), you may need to also use `-i` if the branch has config different from the database to be pulled.
 
 If an admin account username is provided but no password is supplied, Jorge will prompt you for one. If you leave that blank also, the password will not be reset.
 

--- a/tests/coverage.xml
+++ b/tests/coverage.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<coverage generated="1550634543">
-  <project timestamp="1550634543">
+<coverage generated="1556208574">
+  <project timestamp="1556208574">
     <package name="MountHolyoke\Jorge\Command">
       <file name="/Users/jproctor/Projects/jorge/src/Command/DrushCommand.php">
         <class name="MountHolyoke\Jorge\Command\DrushCommand" namespace="MountHolyoke\Jorge\Command">
-          <metrics complexity="19" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="45" coveredstatements="45" elements="50" coveredelements="50"/>
+          <metrics complexity="18" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="43" coveredstatements="43" elements="48" coveredelements="48"/>
         </class>
         <line num="38" type="method" name="__construct" visibility="public" complexity="1" crap="1" count="22"/>
         <line num="39" type="stmt" count="22"/>
@@ -38,7 +38,7 @@
         <line num="125" type="stmt" count="1"/>
         <line num="128" type="stmt" count="2"/>
         <line num="130" type="stmt" count="2"/>
-        <line num="143" type="method" name="initialize" visibility="protected" complexity="12" crap="12" count="1"/>
+        <line num="143" type="method" name="initialize" visibility="protected" complexity="11" crap="11" count="1"/>
         <line num="144" type="stmt" count="1"/>
         <line num="146" type="stmt" count="1"/>
         <line num="147" type="stmt" count="1"/>
@@ -54,9 +54,7 @@
         <line num="160" type="stmt" count="1"/>
         <line num="162" type="stmt" count="1"/>
         <line num="164" type="stmt" count="1"/>
-        <line num="165" type="stmt" count="1"/>
-        <line num="167" type="stmt" count="1"/>
-        <metrics loc="168" ncloc="114" classes="1" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="45" coveredstatements="45" elements="50" coveredelements="50"/>
+        <metrics loc="165" ncloc="111" classes="1" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="43" coveredstatements="43" elements="48" coveredelements="48"/>
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Command/HonkCommand.php">
         <class name="MountHolyoke\Jorge\Command\HonkCommand" namespace="MountHolyoke\Jorge\Command">
@@ -74,7 +72,7 @@
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Command/ResetCommand.php">
         <class name="MountHolyoke\Jorge\Command\ResetCommand" namespace="MountHolyoke\Jorge\Command">
-          <metrics complexity="35" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="115" coveredstatements="115" elements="121" coveredelements="121"/>
+          <metrics complexity="39" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="129" coveredstatements="129" elements="135" coveredelements="135"/>
         </class>
         <line num="37" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="24"/>
         <line num="39" type="stmt" count="24"/>
@@ -87,117 +85,131 @@
         <line num="46" type="stmt" count="24"/>
         <line num="47" type="stmt" count="24"/>
         <line num="48" type="stmt" count="24"/>
-        <line num="52" type="stmt" count="24"/>
-        <line num="60" type="stmt" count="24"/>
-        <line num="70" type="method" name="initialize" visibility="protected" complexity="10" crap="10" count="3"/>
-        <line num="71" type="stmt" count="3"/>
-        <line num="72" type="stmt" count="3"/>
+        <line num="49" type="stmt" count="24"/>
+        <line num="53" type="stmt" count="24"/>
+        <line num="62" type="stmt" count="24"/>
+        <line num="72" type="method" name="initialize" visibility="protected" complexity="10" crap="10" count="3"/>
         <line num="73" type="stmt" count="3"/>
         <line num="74" type="stmt" count="3"/>
         <line num="75" type="stmt" count="3"/>
-        <line num="76" type="stmt" count="2"/>
-        <line num="78" type="stmt" count="3"/>
-        <line num="79" type="stmt" count="3"/>
-        <line num="85" type="stmt" count="3"/>
-        <line num="86" type="stmt" count="3"/>
+        <line num="76" type="stmt" count="3"/>
+        <line num="77" type="stmt" count="3"/>
+        <line num="78" type="stmt" count="2"/>
+        <line num="80" type="stmt" count="3"/>
+        <line num="81" type="stmt" count="1"/>
         <line num="87" type="stmt" count="3"/>
-        <line num="88" type="stmt" count="1"/>
-        <line num="89" type="stmt" count="1"/>
-        <line num="91" type="stmt" count="3"/>
-        <line num="92" type="stmt" count="1"/>
-        <line num="95" type="stmt" count="3"/>
-        <line num="96" type="stmt" count="3"/>
+        <line num="88" type="stmt" count="3"/>
+        <line num="89" type="stmt" count="3"/>
+        <line num="90" type="stmt" count="1"/>
+        <line num="91" type="stmt" count="1"/>
+        <line num="93" type="stmt" count="3"/>
+        <line num="94" type="stmt" count="1"/>
         <line num="97" type="stmt" count="3"/>
+        <line num="98" type="stmt" count="3"/>
         <line num="99" type="stmt" count="3"/>
-        <line num="110" type="method" name="interact" visibility="protected" complexity="3" crap="3" count="1"/>
-        <line num="111" type="stmt" count="1"/>
-        <line num="112" type="stmt" count="1"/>
+        <line num="101" type="stmt" count="3"/>
+        <line num="112" type="method" name="interact" visibility="protected" complexity="3" crap="3" count="1"/>
         <line num="113" type="stmt" count="1"/>
-        <line num="116" type="stmt" count="1"/>
+        <line num="114" type="stmt" count="1"/>
+        <line num="115" type="stmt" count="1"/>
         <line num="118" type="stmt" count="1"/>
-        <line num="129" type="method" name="execute" visibility="protected" complexity="5" crap="5" count="3"/>
-        <line num="130" type="stmt" count="3"/>
-        <line num="131" type="stmt" count="3"/>
-        <line num="132" type="stmt" count="1"/>
-        <line num="134" type="stmt" count="2"/>
-        <line num="135" type="stmt" count="1"/>
+        <line num="120" type="stmt" count="1"/>
+        <line num="131" type="method" name="execute" visibility="protected" complexity="5" crap="5" count="3"/>
+        <line num="132" type="stmt" count="3"/>
+        <line num="133" type="stmt" count="3"/>
+        <line num="134" type="stmt" count="1"/>
+        <line num="136" type="stmt" count="2"/>
         <line num="137" type="stmt" count="1"/>
         <line num="139" type="stmt" count="1"/>
-        <line num="140" type="stmt" count="1"/>
         <line num="141" type="stmt" count="1"/>
         <line num="142" type="stmt" count="1"/>
         <line num="143" type="stmt" count="1"/>
+        <line num="144" type="stmt" count="1"/>
         <line num="145" type="stmt" count="1"/>
-        <line num="146" type="stmt" count="1"/>
         <line num="147" type="stmt" count="1"/>
         <line num="148" type="stmt" count="1"/>
+        <line num="149" type="stmt" count="1"/>
         <line num="150" type="stmt" count="1"/>
         <line num="152" type="stmt" count="1"/>
-        <line num="165" type="method" name="executeDrupal7" visibility="protected" complexity="8" crap="8" count="1"/>
-        <line num="166" type="stmt" count="1"/>
-        <line num="167" type="stmt" count="1"/>
-        <line num="170" type="stmt" count="1"/>
-        <line num="171" type="stmt" count="1"/>
+        <line num="154" type="stmt" count="1"/>
+        <line num="167" type="method" name="executeDrupal7" visibility="protected" complexity="9" crap="9" count="1"/>
+        <line num="168" type="stmt" count="1"/>
+        <line num="169" type="stmt" count="1"/>
         <line num="172" type="stmt" count="1"/>
         <line num="173" type="stmt" count="1"/>
+        <line num="174" type="stmt" count="1"/>
         <line num="175" type="stmt" count="1"/>
-        <line num="176" type="stmt" count="1"/>
         <line num="177" type="stmt" count="1"/>
         <line num="178" type="stmt" count="1"/>
         <line num="179" type="stmt" count="1"/>
         <line num="180" type="stmt" count="1"/>
+        <line num="181" type="stmt" count="1"/>
         <line num="182" type="stmt" count="1"/>
-        <line num="183" type="stmt" count="1"/>
         <line num="184" type="stmt" count="1"/>
         <line num="185" type="stmt" count="1"/>
+        <line num="186" type="stmt" count="1"/>
         <line num="187" type="stmt" count="1"/>
         <line num="189" type="stmt" count="1"/>
         <line num="191" type="stmt" count="1"/>
-        <line num="192" type="stmt" count="1"/>
         <line num="193" type="stmt" count="1"/>
+        <line num="194" type="stmt" count="1"/>
         <line num="195" type="stmt" count="1"/>
         <line num="196" type="stmt" count="1"/>
-        <line num="197" type="stmt" count="1"/>
-        <line num="200" type="stmt" count="1"/>
+        <line num="198" type="stmt" count="1"/>
+        <line num="199" type="stmt" count="1"/>
+        <line num="201" type="stmt" count="1"/>
+        <line num="202" type="stmt" count="1"/>
         <line num="203" type="stmt" count="1"/>
-        <line num="204" type="stmt" count="1"/>
-        <line num="205" type="stmt" count="1"/>
         <line num="206" type="stmt" count="1"/>
-        <line num="208" type="stmt" count="1"/>
-        <line num="219" type="method" name="executeDrupal8" visibility="protected" complexity="8" crap="8" count="1"/>
-        <line num="220" type="stmt" count="1"/>
-        <line num="221" type="stmt" count="1"/>
-        <line num="222" type="stmt" count="1"/>
-        <line num="225" type="stmt" count="1"/>
+        <line num="209" type="stmt" count="1"/>
+        <line num="210" type="stmt" count="1"/>
+        <line num="211" type="stmt" count="1"/>
+        <line num="212" type="stmt" count="1"/>
+        <line num="214" type="stmt" count="1"/>
+        <line num="225" type="method" name="executeDrupal8" visibility="protected" complexity="11" crap="11" count="1"/>
         <line num="226" type="stmt" count="1"/>
         <line num="227" type="stmt" count="1"/>
         <line num="228" type="stmt" count="1"/>
-        <line num="230" type="stmt" count="1"/>
         <line num="231" type="stmt" count="1"/>
         <line num="232" type="stmt" count="1"/>
         <line num="233" type="stmt" count="1"/>
         <line num="234" type="stmt" count="1"/>
-        <line num="235" type="stmt" count="1"/>
         <line num="236" type="stmt" count="1"/>
+        <line num="237" type="stmt" count="1"/>
         <line num="238" type="stmt" count="1"/>
         <line num="239" type="stmt" count="1"/>
         <line num="240" type="stmt" count="1"/>
         <line num="241" type="stmt" count="1"/>
+        <line num="242" type="stmt" count="1"/>
         <line num="243" type="stmt" count="1"/>
         <line num="245" type="stmt" count="1"/>
+        <line num="247" type="stmt" count="1"/>
         <line num="248" type="stmt" count="1"/>
+        <line num="249" type="stmt" count="1"/>
+        <line num="251" type="stmt" count="1"/>
         <line num="252" type="stmt" count="1"/>
         <line num="253" type="stmt" count="1"/>
-        <line num="255" type="stmt" count="1"/>
+        <line num="254" type="stmt" count="1"/>
         <line num="256" type="stmt" count="1"/>
-        <line num="257" type="stmt" count="1"/>
+        <line num="258" type="stmt" count="1"/>
+        <line num="260" type="stmt" count="1"/>
         <line num="261" type="stmt" count="1"/>
+        <line num="262" type="stmt" count="1"/>
         <line num="263" type="stmt" count="1"/>
-        <line num="264" type="stmt" count="1"/>
         <line num="265" type="stmt" count="1"/>
         <line num="266" type="stmt" count="1"/>
+        <line num="267" type="stmt" count="1"/>
         <line num="268" type="stmt" count="1"/>
-        <metrics loc="269" ncloc="193" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="115" coveredstatements="115" elements="121" coveredelements="121"/>
+        <line num="270" type="stmt" count="1"/>
+        <line num="271" type="stmt" count="1"/>
+        <line num="272" type="stmt" count="1"/>
+        <line num="276" type="stmt" count="1"/>
+        <line num="278" type="stmt" count="1"/>
+        <line num="279" type="stmt" count="1"/>
+        <line num="280" type="stmt" count="1"/>
+        <line num="281" type="stmt" count="1"/>
+        <line num="283" type="stmt" count="1"/>
+        <metrics loc="284" ncloc="208" classes="1" methods="6" coveredmethods="6" conditionals="0" coveredconditionals="0" statements="129" coveredstatements="129" elements="135" coveredelements="135"/>
       </file>
     </package>
     <package name="MountHolyoke\Jorge\Helper">
@@ -342,22 +354,17 @@
     <package name="MountHolyoke\Jorge\Tool">
       <file name="/Users/jproctor/Projects/jorge/src/Tool/ComposerTool.php">
         <class name="MountHolyoke\Jorge\Tool\ComposerTool" namespace="MountHolyoke\Jorge\Tool">
-          <metrics complexity="23" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="59" coveredstatements="59" elements="64" coveredelements="64"/>
+          <metrics complexity="23" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="54" coveredstatements="54" elements="59" coveredelements="59"/>
         </class>
         <line num="29" type="method" name="applyVerbosity" visibility="protected" complexity="6" crap="6" count="2"/>
         <line num="30" type="stmt" count="2"/>
-        <line num="31" type="stmt" count="2"/>
         <line num="32" type="stmt" count="1"/>
         <line num="33" type="stmt" count="1"/>
-        <line num="34" type="stmt" count="2"/>
         <line num="36" type="stmt" count="2"/>
-        <line num="37" type="stmt" count="1"/>
         <line num="38" type="stmt" count="1"/>
         <line num="39" type="stmt" count="1"/>
-        <line num="40" type="stmt" count="1"/>
         <line num="41" type="stmt" count="1"/>
         <line num="42" type="stmt" count="1"/>
-        <line num="43" type="stmt" count="1"/>
         <line num="44" type="stmt" count="1"/>
         <line num="45" type="stmt" count="1"/>
         <line num="47" type="stmt" count="2"/>
@@ -408,11 +415,11 @@
         <line num="139" type="stmt" count="4"/>
         <line num="140" type="stmt" count="4"/>
         <line num="142" type="stmt" count="4"/>
-        <metrics loc="143" ncloc="107" classes="1" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="59" coveredstatements="59" elements="64" coveredelements="64"/>
+        <metrics loc="143" ncloc="107" classes="1" methods="5" coveredmethods="5" conditionals="0" coveredconditionals="0" statements="54" coveredstatements="54" elements="59" coveredelements="59"/>
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Tool/GitTool.php">
         <class name="MountHolyoke\Jorge\Tool\GitTool" namespace="MountHolyoke\Jorge\Tool">
-          <metrics complexity="14" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="42" coveredstatements="42" elements="46" coveredelements="46"/>
+          <metrics complexity="14" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="43" coveredstatements="43" elements="47" coveredelements="47"/>
         </class>
         <line num="32" type="method" name="applyVerbosity" visibility="protected" complexity="7" crap="7" count="1"/>
         <line num="35" type="stmt" count="1"/>
@@ -421,6 +428,7 @@
         <line num="39" type="stmt" count="1"/>
         <line num="43" type="stmt" count="1"/>
         <line num="51" type="stmt" count="1"/>
+        <line num="52" type="stmt" count="1"/>
         <line num="53" type="stmt" count="1"/>
         <line num="54" type="stmt" count="1"/>
         <line num="55" type="stmt" count="1"/>
@@ -460,11 +468,11 @@
         <line num="112" type="stmt" count="6"/>
         <line num="113" type="stmt" count="6"/>
         <line num="114" type="stmt" count="6"/>
-        <metrics loc="115" ncloc="74" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="42" coveredstatements="42" elements="46" coveredelements="46"/>
+        <metrics loc="115" ncloc="74" classes="1" methods="4" coveredmethods="4" conditionals="0" coveredconditionals="0" statements="43" coveredstatements="43" elements="47" coveredelements="47"/>
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Tool/LandoTool.php">
         <class name="MountHolyoke\Jorge\Tool\LandoTool" namespace="MountHolyoke\Jorge\Tool">
-          <metrics complexity="45" methods="8" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="120" coveredstatements="120" elements="128" coveredelements="128"/>
+          <metrics complexity="46" methods="8" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="122" coveredstatements="122" elements="130" coveredelements="130"/>
         </class>
         <line num="28" type="method" name="applyVerbosity" visibility="protected" complexity="2" crap="2" count="2"/>
         <line num="30" type="stmt" count="2"/>
@@ -474,7 +482,7 @@
         <line num="46" type="method" name="configure" visibility="protected" complexity="1" crap="1" count="22"/>
         <line num="47" type="stmt" count="22"/>
         <line num="48" type="stmt" count="22"/>
-        <line num="55" type="method" name="getVersion" visibility="public" complexity="13" crap="13" count="5"/>
+        <line num="55" type="method" name="getVersion" visibility="public" complexity="14" crap="14" count="5"/>
         <line num="56" type="stmt" count="5"/>
         <line num="57" type="stmt" count="4"/>
         <line num="60" type="stmt" count="5"/>
@@ -502,99 +510,101 @@
         <line num="93" type="stmt" count="5"/>
         <line num="94" type="stmt" count="5"/>
         <line num="95" type="stmt" count="5"/>
+        <line num="97" type="stmt" count="5"/>
         <line num="98" type="stmt" count="5"/>
-        <line num="99" type="stmt" count="1"/>
+        <line num="99" type="stmt" count="5"/>
         <line num="100" type="stmt" count="1"/>
         <line num="101" type="stmt" count="1"/>
-        <line num="102" type="stmt" count="5"/>
+        <line num="102" type="stmt" count="1"/>
         <line num="103" type="stmt" count="5"/>
         <line num="104" type="stmt" count="5"/>
         <line num="105" type="stmt" count="5"/>
-        <line num="106" type="stmt" count="2"/>
+        <line num="106" type="stmt" count="5"/>
         <line num="107" type="stmt" count="2"/>
-        <line num="108" type="stmt" count="1"/>
-        <line num="109" type="stmt" count="5"/>
-        <line num="112" type="stmt" count="2"/>
-        <line num="113" type="stmt" count="1"/>
-        <line num="114" type="stmt" count="1"/>
+        <line num="108" type="stmt" count="2"/>
+        <line num="109" type="stmt" count="1"/>
+        <line num="110" type="stmt" count="5"/>
+        <line num="114" type="stmt" count="2"/>
         <line num="115" type="stmt" count="1"/>
         <line num="116" type="stmt" count="1"/>
         <line num="117" type="stmt" count="1"/>
-        <line num="121" type="stmt" count="5"/>
-        <line num="127" type="method" name="initialize" visibility="protected" complexity="4" crap="4" count="19"/>
-        <line num="128" type="stmt" count="19"/>
+        <line num="118" type="stmt" count="1"/>
+        <line num="119" type="stmt" count="1"/>
+        <line num="123" type="stmt" count="5"/>
+        <line num="129" type="method" name="initialize" visibility="protected" complexity="4" crap="4" count="19"/>
         <line num="130" type="stmt" count="19"/>
-        <line num="131" type="stmt" count="1"/>
-        <line num="132" type="stmt" count="1"/>
-        <line num="135" type="stmt" count="19"/>
-        <line num="136" type="stmt" count="2"/>
-        <line num="137" type="stmt" count="2"/>
-        <line num="141" type="stmt" count="18"/>
-        <line num="142" type="stmt" count="18"/>
+        <line num="132" type="stmt" count="19"/>
+        <line num="133" type="stmt" count="1"/>
+        <line num="134" type="stmt" count="1"/>
+        <line num="137" type="stmt" count="19"/>
+        <line num="138" type="stmt" count="2"/>
+        <line num="139" type="stmt" count="2"/>
         <line num="143" type="stmt" count="18"/>
+        <line num="144" type="stmt" count="18"/>
         <line num="145" type="stmt" count="18"/>
-        <line num="155" type="method" name="needsAuth" visibility="public" complexity="1" crap="1" count="1"/>
-        <line num="156" type="stmt" count="1"/>
+        <line num="147" type="stmt" count="18"/>
+        <line num="156" type="method" name="needsAuth" visibility="public" complexity="1" crap="1" count="1"/>
         <line num="157" type="stmt" count="1"/>
-        <line num="168" type="method" name="parseLandoList" visibility="protected" complexity="13" crap="13" count="3"/>
-        <line num="170" type="stmt" count="3"/>
-        <line num="171" type="stmt" count="2"/>
-        <line num="174" type="stmt" count="3"/>
-        <line num="176" type="stmt" count="1"/>
+        <line num="158" type="stmt" count="1"/>
+        <line num="167" type="method" name="parseLandoList" visibility="protected" complexity="13" crap="13" count="3"/>
+        <line num="169" type="stmt" count="3"/>
+        <line num="170" type="stmt" count="2"/>
+        <line num="173" type="stmt" count="3"/>
+        <line num="175" type="stmt" count="1"/>
+        <line num="180" type="stmt" count="3"/>
         <line num="181" type="stmt" count="3"/>
         <line num="182" type="stmt" count="3"/>
-        <line num="183" type="stmt" count="3"/>
-        <line num="185" type="stmt" count="3"/>
-        <line num="187" type="stmt" count="3"/>
-        <line num="188" type="stmt" count="1"/>
-        <line num="191" type="stmt" count="3"/>
-        <line num="192" type="stmt" count="2"/>
-        <line num="194" type="stmt" count="1"/>
-        <line num="202" type="stmt" count="2"/>
+        <line num="184" type="stmt" count="3"/>
+        <line num="186" type="stmt" count="3"/>
+        <line num="187" type="stmt" count="1"/>
+        <line num="190" type="stmt" count="3"/>
+        <line num="191" type="stmt" count="2"/>
+        <line num="193" type="stmt" count="1"/>
+        <line num="201" type="stmt" count="2"/>
+        <line num="203" type="stmt" count="2"/>
         <line num="204" type="stmt" count="2"/>
         <line num="205" type="stmt" count="2"/>
-        <line num="206" type="stmt" count="2"/>
-        <line num="207" type="stmt" count="1"/>
-        <line num="209" type="stmt" count="2"/>
+        <line num="206" type="stmt" count="1"/>
+        <line num="208" type="stmt" count="2"/>
+        <line num="210" type="stmt" count="2"/>
         <line num="211" type="stmt" count="2"/>
         <line num="212" type="stmt" count="2"/>
         <line num="213" type="stmt" count="2"/>
         <line num="214" type="stmt" count="2"/>
-        <line num="215" type="stmt" count="2"/>
-        <line num="217" type="stmt" count="2"/>
-        <line num="220" type="stmt" count="2"/>
-        <line num="226" type="method" name="requireStarted" visibility="public" complexity="4" crap="4" count="1"/>
+        <line num="216" type="stmt" count="2"/>
+        <line num="219" type="stmt" count="2"/>
+        <line num="225" type="method" name="requireStarted" visibility="public" complexity="4" crap="4" count="1"/>
+        <line num="226" type="stmt" count="1"/>
         <line num="227" type="stmt" count="1"/>
         <line num="228" type="stmt" count="1"/>
         <line num="229" type="stmt" count="1"/>
-        <line num="230" type="stmt" count="1"/>
-        <line num="232" type="stmt" count="1"/>
-        <line num="242" type="method" name="updateStatus" visibility="public" complexity="7" crap="7" count="2"/>
+        <line num="231" type="stmt" count="1"/>
+        <line num="241" type="method" name="updateStatus" visibility="public" complexity="7" crap="7" count="2"/>
+        <line num="242" type="stmt" count="2"/>
         <line num="243" type="stmt" count="2"/>
         <line num="244" type="stmt" count="2"/>
-        <line num="245" type="stmt" count="2"/>
+        <line num="246" type="stmt" count="1"/>
         <line num="247" type="stmt" count="1"/>
         <line num="248" type="stmt" count="1"/>
-        <line num="249" type="stmt" count="1"/>
-        <line num="251" type="stmt" count="1"/>
+        <line num="250" type="stmt" count="1"/>
+        <line num="254" type="stmt" count="2"/>
         <line num="255" type="stmt" count="2"/>
         <line num="256" type="stmt" count="2"/>
         <line num="257" type="stmt" count="2"/>
         <line num="258" type="stmt" count="2"/>
-        <line num="259" type="stmt" count="2"/>
+        <line num="261" type="stmt" count="2"/>
         <line num="262" type="stmt" count="2"/>
         <line num="263" type="stmt" count="2"/>
         <line num="264" type="stmt" count="2"/>
-        <line num="265" type="stmt" count="2"/>
+        <line num="265" type="stmt" count="1"/>
         <line num="266" type="stmt" count="1"/>
-        <line num="267" type="stmt" count="2"/>
+        <line num="269" type="stmt" count="2"/>
         <line num="270" type="stmt" count="2"/>
         <line num="271" type="stmt" count="2"/>
         <line num="272" type="stmt" count="2"/>
         <line num="273" type="stmt" count="2"/>
-        <line num="274" type="stmt" count="2"/>
-        <line num="277" type="stmt" count="2"/>
-        <metrics loc="278" ncloc="199" classes="1" methods="8" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="120" coveredstatements="120" elements="128" coveredelements="128"/>
+        <line num="276" type="stmt" count="2"/>
+        <metrics loc="277" ncloc="201" classes="1" methods="8" coveredmethods="8" conditionals="0" coveredconditionals="0" statements="122" coveredstatements="122" elements="130" coveredelements="130"/>
       </file>
       <file name="/Users/jproctor/Projects/jorge/src/Tool/Tool.php">
         <class name="MountHolyoke\Jorge\Tool\Tool" namespace="MountHolyoke\Jorge\Tool">
@@ -707,6 +717,6 @@
         <metrics loc="320" ncloc="191" classes="1" methods="20" coveredmethods="19" conditionals="0" coveredconditionals="0" statements="84" coveredstatements="76" elements="104" coveredelements="95"/>
       </file>
     </package>
-    <metrics files="10" loc="1692" ncloc="1121" classes="10" methods="67" coveredmethods="66" conditionals="0" coveredconditionals="0" statements="571" coveredstatements="563" elements="638" coveredelements="629"/>
+    <metrics files="10" loc="1703" ncloc="1135" classes="10" methods="67" coveredmethods="66" conditionals="0" coveredconditionals="0" statements="581" coveredstatements="573" elements="648" coveredelements="639"/>
   </project>
 </coverage>


### PR DESCRIPTION
`jorge reset -b `_`{branch}`_ correctly resets to the specified branch, but does not import config into the database if it’s different from **master**.

This branch adds the `--import`/`-i` flag to allow that.
