### PR TITLE
Drush 9

### DIFF
--- a/src/Command/DrushCommand.php
+++ b/src/Command/DrushCommand.php
@@ -38,18 +38,19 @@ class DrushCommand extends Command {
   public function __construct(string $name = NULL) {
     parent::__construct($name);
     $this->interaction = [
-      'cc'     => FALSE,
-      'cex'    => TRUE,
-      'cim'    => TRUE,
-      'cr'     => FALSE,
-      'csim'   => TRUE,
-      'en'     => TRUE,
-      'ms'     => FALSE,
-      'pmu'    => TRUE,
-      'status' => FALSE,
-      'updb'   => TRUE,
-      'ups'    => FALSE,
-      'upwd'   => FALSE,
+      'cc'      => FALSE,
+      'cex'     => TRUE,
+      'cim'     => TRUE,
+      'cr'      => FALSE,
+      'csim'    => TRUE,
+      'en'      => TRUE,
+      'ms'      => FALSE,
+      'pmu'     => TRUE,
+      'status'  => FALSE,
+      'updb'    => TRUE,
+      'ups'     => FALSE,
+      'upwd'    => FALSE,
+      'version' => FALSE,
     ];
   }
 

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -265,11 +265,12 @@ class ResetCommand extends Command {
     $drushSequence[] = ['drush_command' => ['csim', 'config_dev'], '--yes' => TRUE];
     $drushSequence[] = ['drush_command' => ['updb'],               '--yes' => TRUE];
     if (!empty($this->params['username']) && !empty($this->params['password'])) {
+      $passwordFlag = ($lando->getDrushVersion() < 9) ? '--password=' : '';
       $drushSequence[] = [
         'drush_command' => [
           'upwd',
           $this->params['username'],
-          '--password="' . $this->params['password'] . '"',
+          $passwordFlag . '"' . $this->params['password'] . '"',
         ],
       ];
     }

--- a/src/Tool/LandoTool.php
+++ b/src/Tool/LandoTool.php
@@ -48,6 +48,22 @@ class LandoTool extends Tool {
   }
 
   /**
+   * Gets the Drush version.
+   *
+   * TODO: This really belongs in the Drush command but it was easier here.
+   */
+  public function getDrushVersion() {
+    $exec = $this->exec('drush version');
+    if ($exec['status'] != 0 || !array_key_exists('output', $exec) || count($exec['output']) == 0) {
+      $this->log(LogLevel::ERROR, 'Unable to determine Drush version');
+      $this->disable();
+      return NULL;
+    }
+    preg_match('/Drush version : (\d+)\./', $exec['output'][0], $matches);
+    return $matches[1];
+  }
+
+  /**
    * Gets the version of Lando installed so we can parse its output.
    *
    * @return array|null


### PR DESCRIPTION
This branch adds a public method `getDrushVersion()` to LandoTool to get the major version of Drush that it’s using, then calls it from ResetCommand to determine whether to include `--password=` when setting the admin password.

This approach is problematic in several ways, not least of which is that it breaks the PHPUnit tests _and_ really ought to be encapsulated in the DrushCommand, but it’s expedient to meet an immediate need, so I’m going to bundle up a release and fix it later.
